### PR TITLE
Streamline CMake setup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,12 @@
+cmake_minimum_required (VERSION 3.5)
 project(hipSYCL)
 
-set(CMAKE_CXX_COMPILER ${PROJECT_SOURCE_DIR}/bin/syclcc)
+# Make sure either hcc or nvcc can be found
+find_program(VENDOR_DEVICE_COMPILER NAMES hcc nvcc)
+if(VENDOR_DEVICE_COMPILER MATCHES "-NOTFOUND")
+  message(SEND_ERROR "Neither 'hcc' nor 'nvcc' was found in PATH")
+endif()
+set(HIPSYCL_DEVICE_COMPILER ${PROJECT_SOURCE_DIR}/bin/syclcc)
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
@@ -21,11 +27,7 @@ endif()
 #Use add_definitions for now for older cmake versions
 cmake_policy(SET CMP0005 NEW)
 add_definitions(-DHIPSYCL_DEBUG_LEVEL=${HIPSYCL_DEBUG_LEVEL})
-
-cmake_minimum_required (VERSION 3.5)
-
-include_directories(${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR}/include)
-subdirs(src)
+add_subdirectory(src)
 
 install(DIRECTORY include/CL DESTINATION include/
         FILES_MATCHING PATTERN "*.hpp")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,19 +1,4 @@
-subdirs(libhipSYCL)
+add_subdirectory(libhipSYCL)
+add_subdirectory(hipsycl_rewrite_includes)
+add_subdirectory(hipsycl_transform_source)
 
-include(ExternalProject)
-
-# We compile these tools as external projects so they are
-# able to use the default system compiler. They don't need
-# to be compiled by the device compiler, so we can just use
-# the regular one
-ExternalProject_Add(hipsycl_rewrite_includes
-  SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/hipsycl_rewrite_includes
-  INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
-  CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DHIPSYCL_DEBUG_LEVEL=${HIPSYCL_DEBUG_LEVEL} -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
-)
-
-ExternalProject_Add(hipsycl_transform_source
-  SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/hipsycl_transform_source
-  INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
-  CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DHIPSYCL_DEBUG_LEVEL=${HIPSYCL_DEBUG_LEVEL} -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
-)

--- a/src/hipsycl_rewrite_includes/CMakeLists.txt
+++ b/src/hipsycl_rewrite_includes/CMakeLists.txt
@@ -1,23 +1,26 @@
+cmake_minimum_required(VERSION 3.5)
 project(hipsycl_rewrite_includes)
-cmake_minimum_required (VERSION 3.5)
 
-find_package(LLVM REQUIRED)
+find_package(LLVM REQUIRED CONFIG)
 #This seems to configure linkage incorrectly, so let's just assume clang is installed
-#find_package(Clang REQUIRED)
+#find_package(Clang REQUIRED CONFIG)
 find_package(Boost REQUIRED)
 
 find_program(CLANG_EXECUTABLE_PATH NAMES clang CACHE STRING)
+if(CLANG_EXECUTABLE_PATH MATCHES "-NOTFOUND")
+  message(SEND_ERROR "Could not find 'clang' executable in PATH")
+endif()
 get_filename_component(CLANG_BINARY_PREFIX ${CLANG_EXECUTABLE_PATH} DIRECTORY)
-
-add_executable(hipsycl_rewrite_includes
-  HipsyclRewriteIncludes.cpp
-  InclusionRewriter.cpp)
 
 if(NOT HIPSYCL_DEBUG_LEVEL)
   set(HIPSYCL_DEBUG_LEVEL 1 CACHE INTEGER)
 endif()
 
 add_definitions(-DHIPSYCL_DEBUG_LEVEL=${HIPSYCL_DEBUG_LEVEL})
+
+add_executable(hipsycl_rewrite_includes
+  HipsyclRewriteIncludes.cpp
+  InclusionRewriter.cpp)
 
 target_include_directories(hipsycl_rewrite_includes PRIVATE
   ${LLVM_INCLUDE_DIRS}
@@ -29,13 +32,8 @@ target_compile_definitions(hipsycl_rewrite_includes PRIVATE
   ${LLVM_DEFINITIONS}
   HIPSYCL_TRANSFORM_CLANG_DIR=${CLANG_BINARY_PREFIX})
 
-
-link_directories(${LLVM_LIBRARY_DIRS})
-
-target_compile_definitions(hipsycl_rewrite_includes PRIVATE
-  ${LLVM_DEFINITIONS})
 target_link_libraries(hipsycl_rewrite_includes
-  -lLLVM
+  LLVM
   clangFrontend
   clangSerialization
   clangDriver

--- a/src/hipsycl_transform_source/CMakeLists.txt
+++ b/src/hipsycl_transform_source/CMakeLists.txt
@@ -1,12 +1,15 @@
-project(hipsycl_transform_source)
 cmake_minimum_required(VERSION 3.5)
+project(hipsycl_transform_source)
 
-find_package(LLVM REQUIRED)
+find_package(LLVM REQUIRED CONFIG)
 #This seems to configure linkage incorrectly, so let's just assume clang is installed
-#find_package(Clang REQUIRED)
+#find_package(Clang REQUIRED CONFIG)
 find_package(Boost REQUIRED)
 
 find_program(CLANG_EXECUTABLE_PATH NAMES clang CACHE STRING)
+if(CLANG_EXECUTABLE_PATH MATCHES "-NOTFOUND")
+  message(SEND_ERROR "Could not find 'clang' executable in PATH")
+endif()
 get_filename_component(CLANG_BINARY_PREFIX ${CLANG_EXECUTABLE_PATH} DIRECTORY)
 
 if(NOT HIPSYCL_DEBUG_LEVEL)
@@ -28,19 +31,12 @@ target_include_directories(hipsycl_transform_source PRIVATE
   ${Boost_INCLUDE_DIRS}
   ../../include)
 
-#target_compile_options(hipsycl_transform_source PRIVATE
-#  --force-alternative-compiler=g++)
-#set_target_properties(hipsycl_transform_source PROPERTIES LINK_FLAGS
-#  --force-alternative-compiler=gcc)
-
-link_directories(${LLVM_LIBRARY_DIRS})
-
 target_compile_definitions(hipsycl_transform_source PRIVATE
   ${LLVM_DEFINITIONS}
   HIPSYCL_TRANSFORM_CLANG_DIR=${CLANG_BINARY_PREFIX})
 
 target_link_libraries(hipsycl_transform_source
-  -lLLVM
+  LLVM
   clangFrontend
   clangSerialization
   clangDriver

--- a/src/libhipSYCL/CMakeLists.txt
+++ b/src/libhipSYCL/CMakeLists.txt
@@ -1,3 +1,6 @@
+project(libhipSYCL)
+
+set(CMAKE_CXX_COMPILER ${HIPSYCL_DEVICE_COMPILER})
 
 add_library(hipSYCL SHARED
   device.cpp
@@ -9,6 +12,9 @@ add_library(hipSYCL SHARED
   task_graph.cpp
   accessor.cpp
   async_worker.cpp)
+
+target_include_directories(hipSYCL PRIVATE
+  ../../include)
 
 install(TARGETS hipSYCL
         LIBRARY DESTINATION lib


### PR DESCRIPTION
This is an incremental improvement with the goal of streamlining the whole CMake setup a bit.

- Adds checks that the `hcc`/`nvcc` and `clang` executables were found in PATH, so that we can error during generation, not just at compile time.
- Use `add_subdirectory` instead of `ExternalProject` for the rewrite and transform executables. I understand you tried to have those compiled with the system compiler instead of `syclcc`, but the same effect can be achieved by setting `CMAKE_CXX_COMPILER` within the CMakeLists.txt specific to `libhipSYCL` (as the variable is scoped to that folder). The advantage of this approach is that any configuration problems are again reported during the initial CMake call, instead of during compilation.
- Various minor cleanups/refactorings/consistency changes.

PS: I'm impressed how well the approach you're taking with hipSYCL works - very cool!