### PR TITLE
Add destructor implementation for device_selector

### DIFF
--- a/include/CL/sycl/device_selector.hpp
+++ b/include/CL/sycl/device_selector.hpp
@@ -41,7 +41,7 @@ namespace sycl {
 class device_selector
 {
 public:
-  virtual ~device_selector();
+  virtual ~device_selector() {};
   device select_device() const;
 
   virtual int operator()(const device& dev) const = 0;


### PR DESCRIPTION
It appears that `device_selector` was missing a destructor implementation, which made it so subclasses couldn't be instantiated (throwing a linker error).