### PR TITLE
Fix diagnostic location printing in includes rewriter

### DIFF
--- a/src/hipsycl_rewrite_includes/HipsyclRewriteIncludes.cpp
+++ b/src/hipsycl_rewrite_includes/HipsyclRewriteIncludes.cpp
@@ -89,7 +89,7 @@ public:
     std::string strMessage(message.begin(), message.end());
     std::string location = "<unknown location>";
     if(info.hasSourceManager())
-      std::string location = info.getLocation().printToString(info.getSourceManager());
+      location = info.getLocation().printToString(info.getSourceManager());
 
     if(level == clang::DiagnosticsEngine::Ignored ||
        level == clang::DiagnosticsEngine::Note ||


### PR DESCRIPTION
This fixes a typo in the includes rewriter that causes the diagnostic location not to be correctly set (always printing `<unknown location>`).