### PR TITLE
Handle skipped includes in inclusion rewriter

### DIFF
--- a/tests/rewrite-includes/skipped.hpp
+++ b/tests/rewrite-includes/skipped.hpp
@@ -1,0 +1,7 @@
+#ifndef SKIPPED_HPP
+#define SKIPPED_HPP
+
+// Should only be defined once in rewritten output file
+struct defined_once {};
+
+#endif

--- a/tests/rewrite-includes/test_skipped_includes.cpp
+++ b/tests/rewrite-includes/test_skipped_includes.cpp
@@ -1,0 +1,10 @@
+// This should be rewritten (inlined) and the directive commented out
+#include "skipped.hpp"
+
+// This directive should be commented out
+#include "skipped.hpp"
+
+int main()
+{
+  return 0;
+}


### PR DESCRIPTION
Consider the following example program:

`foo.cpp`:
```c++
#include "foo.h"
#include "foo.h"
int main() { return 0; }
```

`foo.h`:
```c++
#pragma once
struct foo {};
```

This currently causes `syclcc` (`nvcc` actually, `hcc` as well, presumably) to fail with either an error that `foo.h` cannot be found, or because of a duplicate definition of `struct foo` -- depending on whether the build is done out-of-source or not.

Of course this is a contrived example, but the same happens for transitive inclusions of the same header. The reason for this is that after the first `#include` has been processed, all further include directives for the same file are not commented out.

Instead of keeping track of includes on a per-file basis, Clang's `InclusionRewriter` tracks them based on the source location within the _including_ file. This location is naturally different for the two directives in the example above (being on a different line). Crucially, if a file is skipped due to an include guard, the location is not tracked at all. This causes the current implementation to think that a file should not be rewritten, and thus does not comment out the directive. Note that this is not a problem for the mainline Clang implementation, as it always comments out all inclusion directives.

This PR adds an additional data structure that keeps track of any skipped includes and uses that to check whether a `#include` directive should be commented out, even if it is not to be rewritten.