### PR TITLE
hipsycl_transform_source: Use getSourceRange() when pruning uninstantiated templates

### DIFF
--- a/src/hipsycl_transform_source/CompilationTargetAnnotator.cpp
+++ b/src/hipsycl_transform_source/CompilationTargetAnnotator.cpp
@@ -262,7 +262,7 @@ CompilationTargetAnnotator::addAnnotations()
         std::string prefix = ";";
 
         const clang::Stmt *body = d->getBody();
-        auto bodyStart = d->getBody()->getLocStart();
+        auto bodyStart = body->getSourceRange().getBegin();
 
         if(clang::isa<CXXConstructorDecl>(d))
         {
@@ -273,7 +273,7 @@ CompilationTargetAnnotator::addAnnotations()
           prefix = "{}";
         }
 
-        auto bodyEnd   = d->getLocEnd();
+        auto bodyEnd = body->getSourceRange().getEnd();
       
         _rewriter.InsertTextBefore(bodyStart,
             prefix+"\n#if 0 // -- definition stripped by hipsycl_transform_source\n");

--- a/tests/transformation/forward_declared_template.cpp
+++ b/tests/transformation/forward_declared_template.cpp
@@ -1,0 +1,14 @@
+template<typename T>
+void foo(T);
+
+template <typename T>
+void bar(T) {}
+
+template<typename T>
+void foo(T value) {
+    bar(value);
+}
+
+int main() {
+    return 0;
+} 


### PR DESCRIPTION
This attempts to fix issue #14 by using `getSourceRange()` instead of `getLocStart()` and `getLocEnd()`. While the generic implementation of `getSourceRange()` just creates a range from `getLocStart()` to  `getLocEnd()` as one would expect, the specialization in `FunctionDecl` seems to do something else [(see here)](https://clang.llvm.org/doxygen/Decl_8cpp_source.html#l03637).

While it's still unclear to me why `getLocStart()` and `getLocEnd()` behave the way they do for the case described in issue #14, `getSourceRange()` seems to work as expected.