### PR TITLE
Fix class template function pruning

### DIFF
--- a/src/hipsycl_transform_source/CompilationTargetAnnotator.cpp
+++ b/src/hipsycl_transform_source/CompilationTargetAnnotator.cpp
@@ -261,9 +261,6 @@ CompilationTargetAnnotator::addAnnotations()
       if (d->hasBody()) {
 
         const clang::Stmt *body = d->getBody();
-        auto range = body->getSourceRange();
-
-        const clang::FunctionDecl* function = clang::cast<clang::FunctionDecl>(d);
         
         for(auto child = body->child_begin(); child != body->child_end(); ++child)
         {

--- a/tests/transformation/class_template.cpp
+++ b/tests/transformation/class_template.cpp
@@ -1,0 +1,26 @@
+class foo {
+    template<typename T>
+    void bar(T value);
+    
+    template<typename T>
+    int func_with_return_value();
+};
+
+template <typename T>
+void baz(T) {}
+
+template <typename T>
+void foo::bar(T value) {
+    baz(value);
+}
+
+template <typename T>
+int foo::func_with_return_value() {
+    baz(T{});
+    return T{};
+}
+
+
+int main() {
+    return 0;
+}


### PR DESCRIPTION
This fixes issue #16 by, instead of commenting out the entire definition, replacing each statement within a definition with an amount of whitespaces equal to the statement's length.
Apart from fixing issue #16, this has a couple of advantages:
* Simpler code
* Probably more robust against `#ifdef` etc macros inside the function definition since these are not removed (Previously, if there were `ifdef` macros interleaved with the function body, bad things could have happened...)
* Usually does not alter line numbers for diagnostics (to be tested in detail - a statement spanning multiple lines may be an issue)

The changes are tested with code from the SYCL parallel STL and seem to work well with that.

In general, removing all statements from the function body may trigger warnings about missing return statements. This is not a problem in this case because
* nvcc seems to have worse diagnostics than gcc/clang and does not seem to pick up on that
* AMD's compiler is clang-based, so it is expected that such warnings are triggered. However, since it is clang-based, it will work with the same call graph as the hipSYCL source transformation. Therefore, pruning is not even necessary and could be disabled entirely on AMD if this becomes a problem
* In any case we could also just suppress these warnings since we already get full clang-based diagnostics from the hipSYCL source transformation. So, not having missing return statement warnings from nvcc or hcc doesn't hurt.