### PR TITLE
Add option in hipsycl_transform_source to enable template pruning

### DIFF
--- a/src/hipsycl_transform_source/CompilationTargetAnnotator.cpp
+++ b/src/hipsycl_transform_source/CompilationTargetAnnotator.cpp
@@ -235,7 +235,11 @@ CompilationTargetAnnotator::addAnnotations()
       writeAnnotation(f.second, " __host__ ");
     }
   }
+}
 
+void 
+CompilationTargetAnnotator::pruneUninstantiatedTemplates()
+{
   // Prune uninstantiated templates
   for(auto synonymousDeclGroup : _synonymousDecls)
   {

--- a/src/hipsycl_transform_source/CompilationTargetAnnotator.hpp
+++ b/src/hipsycl_transform_source/CompilationTargetAnnotator.hpp
@@ -56,6 +56,8 @@ public:
 
   void addAnnotations();
 
+  void pruneUninstantiatedTemplates();
+
 private:
 
   DeclIdentifier getDeclKey(

--- a/src/hipsycl_transform_source/HipsyclTransform.cpp
+++ b/src/hipsycl_transform_source/HipsyclTransform.cpp
@@ -36,6 +36,9 @@
 namespace hipsycl {
 namespace transform {
 
+CommandLineArgs::CommandLineArgs()
+: _enableTemplatePruning{false}
+{}
 
 std::string
 CommandLineArgs::extractArg(const std::string& optionString) const
@@ -57,6 +60,7 @@ CommandLineArgs::consumeHipsyclArgs(
 
   _transformDirectory = "";
   _mainFilename = "";
+  _enableTemplatePruning = false;
 
   for(std::size_t i = 0; i < args.size(); ++i)
   {
@@ -68,6 +72,10 @@ CommandLineArgs::consumeHipsyclArgs(
     {
       _mainFilename = extractArg(args[i]);
     }
+    else if(args[i] == "--with-template-pruning")
+    {
+      _enableTemplatePruning = true;
+    }
     else
       modifiedArgs.push_back(args[i]);
 
@@ -76,6 +84,12 @@ CommandLineArgs::consumeHipsyclArgs(
   }
 
   return modifiedArgs;
+}
+
+bool 
+CommandLineArgs::isTemplatePruningEnabled() const
+{
+  return _enableTemplatePruning;
 }
 
 std::string
@@ -136,6 +150,8 @@ void HipsyclTransformASTConsumer::HandleTranslationUnit(clang::ASTContext& ctx)
   CompilationTargetAnnotator annotationCorrector{_rewriter, _visitor};
   annotationCorrector.treatConstructsAsFunctionCalls(_constructMatcher);
   annotationCorrector.addAnnotations();
+  if(Application::getCommandLineArgs().isTemplatePruningEnabled())
+    annotationCorrector.pruneUninstantiatedTemplates();
 }
 
 HipsyclTransfromFrontendAction::HipsyclTransfromFrontendAction()

--- a/src/hipsycl_transform_source/HipsyclTransform.hpp
+++ b/src/hipsycl_transform_source/HipsyclTransform.hpp
@@ -49,18 +49,22 @@ namespace transform {
 class CommandLineArgs
 {
 public:
+  CommandLineArgs();
 
   clang::tooling::CommandLineArguments
   consumeHipsyclArgs(const clang::tooling::CommandLineArguments& args);
 
   std::string getTransformDirectory() const;
   std::string getMainFilename() const;
+  bool isTemplatePruningEnabled() const;
 
 private:
   std::string extractArg(const std::string& optionString) const;
 
   std::string _transformDirectory;
   std::string _mainFilename;
+
+  bool _enableTemplatePruning;
 };
 
 class Application


### PR DESCRIPTION
Following the discussion in issue #22, this disables template pruning by default in the source transformation. Pruning can be reenabled by passing `--with-template-pruning` to `hipsycl_transform_source`.
This does not yet include the changes in `syclcc` to enable pruning for `nvcc`, since the relevant parts in `syclcc` will likely have to be refactored somewhat to differentiate between `nvcc` and other cuda compilers like clang that also don't need template pruning.