### PR TITLE
prune templates by commenting function body content

### DIFF
--- a/src/hipsycl_transform_source/CompilationTargetAnnotator.cpp
+++ b/src/hipsycl_transform_source/CompilationTargetAnnotator.cpp
@@ -263,25 +263,15 @@ CompilationTargetAnnotator::pruneUninstantiatedTemplates()
                          << std::endl;
 
       if (d->hasBody()) {
-        std::string prefix = ";";
 
         const clang::Stmt *body = d->getBody();
         auto bodyStart = body->getSourceRange().getBegin();
 
-        if(clang::isa<CXXConstructorDecl>(d))
-        {
-          // If we are a constructor, instead of turning the definition
-          // into a declaration with a ';', we insert an empty definition.
-          // This also works if an initalizer list is present, where
-          // a ';' would be a syntax error.
-          prefix = "{}";
-        }
-
         auto bodyEnd = body->getSourceRange().getEnd();
       
-        _rewriter.InsertTextBefore(bodyStart,
-            prefix+"\n#if 0 // -- definition stripped by hipsycl_transform_source\n");
-        _rewriter.InsertTextAfterToken(bodyEnd, "\n#endif\n");
+        _rewriter.InsertTextAfterToken(bodyStart,
+            "\n#if 0 // -- definition stripped by hipsycl_transform_source\n");
+        _rewriter.InsertText(bodyEnd, "\n#endif\n");
         // TODO: Correct the current #line in the source
       }
     }

--- a/tests/transformation/class_template.cpp
+++ b/tests/transformation/class_template.cpp
@@ -1,0 +1,16 @@
+class foo {
+    template<typename T>
+    void bar(T value);
+};
+
+template <typename T>
+void baz(T) {}
+
+template <typename T>
+void foo::bar(T value) {
+    baz(value);
+}
+
+int main() {
+    return 0;
+}


### PR DESCRIPTION
As a final attempt to fix issue #16 without introducing potential new problems, this causes the pruning step to comment out the content of the template function bodies instead of the bodies themselves. I.e., instead of 
```cpp
template<class T>
void f() ;
#if 0 // -- definition stripped by hipsycl_transform_source
{
  ...
} 
#endif
```
this does
```cpp
template<class T>
void f()
{
#if 0 // -- definition stripped by hipsycl_transform_source
   ...
#endif
} 
```