### PR TITLE
Don't require OpenMP during source transformation

### DIFF
--- a/bin/syclcc
+++ b/bin/syclcc
@@ -145,6 +145,7 @@ class source_file_processor:
          filename, "--",
          "-I" + os.path.dirname(filename),
          "-I" + hipcpu_include_dir,
+         "-DHIPCPU_NO_OPENMP",
          "-Wno-unused-command-line-argument"]
          +self._additional_args
          +self._config.hipsycl_common_arguments)
@@ -160,6 +161,7 @@ class source_file_processor:
          "--",
          "-I" + os.path.dirname(filename),
          "-I" + hipcpu_include_dir,
+         "-DHIPCPU_NO_OPENMP",
          "-Wno-unused-command-line-argument",
          "--hipsycl-transform-dir="+output_dir,
          "--hipsycl-main-output-file="+output_filename]


### PR DESCRIPTION
This disables the requirement for OpenMP during the source transformation step, as suggested in issue #26. This is done using an updated version of hipCPU (make sure the hipCPU submodule is also up-to-date!) and the new macro `HIPCPU_NO_OPENMP`.