### PR TITLE
Travis CI: Clone hipSYCL from correct origin/branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ services:
   - docker
 
 install:
-  - docker build --build-arg hipsycl_branch=`git rev-parse --abbrev-ref HEAD` --build-arg hipsycl_origin=`git config --get remote.origin.url` install/docker/CUDA
-  - docker build --build-arg hipsycl_branch=`git rev-parse --abbrev-ref HEAD` --build-arg hipsycl_origin=`git config --get remote.origin.url` install/docker/ROCm
+  - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
+  - docker build --build-arg hipsycl_branch=$BRANCH --build-arg hipsycl_origin=`git config --get remote.origin.url` install/docker/CUDA
+  - docker build --build-arg hipsycl_branch=$BRANCH --build-arg hipsycl_origin=`git config --get remote.origin.url` install/docker/ROCm
   
 script:
   - docker images

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ services:
   - docker
 
 install:
-  - docker build install/docker/CUDA
-  - docker build install/docker/ROCm
+  - docker build --build-arg hipsycl_branch=`git rev-parse --abbrev-ref HEAD` --build-arg hipsycl_origin=`git config --get remote.origin.url` install/docker/CUDA
+  - docker build --build-arg hipsycl_branch=`git rev-parse --abbrev-ref HEAD` --build-arg hipsycl_origin=`git config --get remote.origin.url` install/docker/ROCm
   
 script:
   - docker images

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,10 @@ services:
 
 install:
   - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
-  - docker build --build-arg hipsycl_branch=$BRANCH --build-arg hipsycl_origin=`git config --get remote.origin.url` install/docker/CUDA
-  - docker build --build-arg hipsycl_branch=$BRANCH --build-arg hipsycl_origin=`git config --get remote.origin.url` install/docker/ROCm
+  - export ORIGIN=`git config --get remote.origin.url`
+  - echo "Testing hipSYCL: Branch $BRANCH from $ORIGIN"
+  - docker build --build-arg hipsycl_branch=$BRANCH --build-arg hipsycl_origin=$ORIGIN install/docker/CUDA
+  - docker build --build-arg hipsycl_branch=$BRANCH --build-arg hipsycl_origin=$ORIGIN install/docker/ROCm
   
 script:
   - docker images

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 install:
   - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
   - export ORIGIN=`git config --get remote.origin.url`
-  - echo "Testing hipSYCL: Branch $BRANCH from $ORIGIN"
+  - echo "Testing hipSYCL, branch $BRANCH from $ORIGIN"
   - docker build --build-arg hipsycl_branch=$BRANCH --build-arg hipsycl_origin=$ORIGIN install/docker/CUDA
   - docker build --build-arg hipsycl_branch=$BRANCH --build-arg hipsycl_origin=$ORIGIN install/docker/ROCm
   

--- a/install/docker/CUDA/Dockerfile
+++ b/install/docker/CUDA/Dockerfile
@@ -1,9 +1,13 @@
 FROM nvidia/cuda:10.0-devel-ubuntu18.04
 
+ARG hipsycl_branch=master
+ARG hipsycl_origin=https://github.com/illuhad/hipSYCL
+ENV hipsycl_branch=$hipsycl_branch
+ENV hipsycl_origin=$hipsycl_origin
 RUN apt-get update
 RUN apt-get install -y git llvm-6.0-dev llvm-6.0 clang-6.0 cmake libboost-dev clang-6.0-dev python3 libclang-6.0-dev
 WORKDIR /tmp
-RUN git clone --recurse-submodules https://github.com/illuhad/hipSYCL
+RUN git clone -b $hipsycl_branch --recurse-submodules $hipsycl_origin
 RUN mkdir /tmp/build
 WORKDIR /tmp/build
 ENV CXX=clang++-6.0

--- a/install/docker/ROCm/Dockerfile
+++ b/install/docker/ROCm/Dockerfile
@@ -1,9 +1,13 @@
 FROM rocm/rocm-terminal
 
+ARG hipsycl_branch=master
+ARG hipsycl_origin=https://github.com/illuhad/hipSYCL
+ENV hipsycl_branch=$hipsycl_branch
+ENV hipsycl_origin=$hipsycl_origin
 RUN sudo apt-get update
 RUN sudo apt-get install -y python3 libclang-6.0-dev clang-6.0 llvm-6.0-dev libboost-dev gcc
 WORKDIR /tmp
-RUN git clone --recurse-submodules https://github.com/illuhad/hipSYCL
+RUN git clone -b $hipsycl_branch --recurse-submodules $hipsycl_origin
 RUN mkdir /tmp/build
 WORKDIR /tmp/build
 USER root


### PR DESCRIPTION
This forwards the currently checked out branch and origin of the git clone into the dockerfiles when running Travis CI. Hopefully, this allows us to test already our PRs with travis CI to get feedback on build status before merging, as mentionend in #24