### PR TITLE
Add option to build hipSYCL with nvcc instead of clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,15 @@ endif()
 # Make sure either hcc or nvcc can be found
 find_program(NVCC_COMPILER NAMES nvcc)
 find_program(HCC_COMPILER NAMES hcc)
+find_program(CLANG_EXECUTABLE_PATH NAMES clang++-8 clang++-8.0 clang++-7.0 clang++-7 clang++-6.0 clang++-6 clang++ CACHE STRING)
+if(CLANG_EXECUTABLE_PATH MATCHES "-NOTFOUND")
+  message(SEND_ERROR "Could not find clang executable in PATH")
+endif()
 
+# Even if we compile with clang, this tests
+# for the existence of CUDA which is also required for clang.
+# TODO: A better approach would be to find_package(CUDA) if
+# we build with clang.
 if(NVCC_COMPILER MATCHES "-NOTFOUND")
   set(CUDA_FOUND false)
 else()
@@ -46,6 +54,10 @@ if(WITH_ROCM_BACKEND)
   if(NOT ROCM_FOUND)
     message(SEND_ERROR "hcc was not found in PATH")
   endif()
+endif()
+
+if(CUDA_FOUND)
+  set(USE_NVCC false CACHE BOOL "Build hipSYCL with nvcc instead of clang as CUDA compiler (not recommended!)")
 endif()
 
 set(WITH_CUDA_BACKEND ${CUDA_FOUND} CACHE BOOL "Build hipSYCL support for NVIDIA GPUs with CUDA")

--- a/src/hipsycl_rewrite_includes/CMakeLists.txt
+++ b/src/hipsycl_rewrite_includes/CMakeLists.txt
@@ -5,10 +5,6 @@ find_package(LLVM REQUIRED CONFIG)
 #find_package(Clang REQUIRED)
 find_package(Boost REQUIRED)
 
-find_program(CLANG_EXECUTABLE_PATH NAMES clang-7.0 clang-7 clang-6.0 clang-6 clang CACHE STRING)
-if(CLANG_EXECUTABLE_PATH MATCHES "-NOTFOUND")
-  message(SEND_ERROR "Could not find clang executable in PATH")
-endif()
 get_filename_component(CLANG_BINARY_PREFIX ${CLANG_EXECUTABLE_PATH} DIRECTORY)
 
 if(NOT HIPSYCL_DEBUG_LEVEL)

--- a/src/hipsycl_transform_source/CMakeLists.txt
+++ b/src/hipsycl_transform_source/CMakeLists.txt
@@ -5,10 +5,7 @@ find_package(LLVM REQUIRED CONFIG)
 #find_package(Clang REQUIRED)
 find_package(Boost REQUIRED)
 
-find_program(CLANG_EXECUTABLE_PATH NAMES clang-7.0 clang-7 clang-6.0 clang-6 clang CACHE STRING)
-if(CLANG_EXECUTABLE_PATH MATCHES "-NOTFOUND")
-  message(SEND_ERROR "Could not find clang executable in PATH")
-endif()
+
 get_filename_component(CLANG_BINARY_PREFIX ${CLANG_EXECUTABLE_PATH} DIRECTORY)
 
 if(NOT HIPSYCL_DEBUG_LEVEL)

--- a/src/libhipSYCL/CMakeLists.txt
+++ b/src/libhipSYCL/CMakeLists.txt
@@ -20,9 +20,16 @@ set(INCLUDE_DIRS
 
 if(WITH_CUDA_BACKEND)
   add_library(hipSYCL_cuda SHARED ${HIPSYCL_SOURCES})
-  target_compile_options(hipSYCL_cuda PRIVATE --hipsycl-platform=cuda --hipsycl-bootstrap)
+
+  if(USE_NVCC)
+    set(CUDA_PLATFORM nvcc)
+  else()
+    set(CUDA_PLATFORM cuda)
+  endif()
+
+  target_compile_options(hipSYCL_cuda PRIVATE --hipsycl-platform=${CUDA_PLATFORM} --hipsycl-bootstrap)
   target_include_directories(hipSYCL_cuda PRIVATE ${INCLUDE_DIRS})
-  target_link_libraries(hipSYCL_cuda --hipsycl-platform=cuda --hipsycl-bootstrap)
+  target_link_libraries(hipSYCL_cuda --hipsycl-platform=${CUDA_PLATFORM} --hipsycl-bootstrap)
   install(TARGETS hipSYCL_cuda
           LIBRARY DESTINATION lib
           ARCHIVE DESTINATION lib/static)


### PR DESCRIPTION
This adds the cmake option `USE_NVCC`, which can be used to compile hipSYCL with nvcc instead of the default CUDA compiler clang. This is useful if a version of clang that is new enough to compile against recent versions of CUDA is not installed.
Additionally, this also moves the code to find clang to the top-level CMakeLists, instead of having it duplicated in `hipsycl_transform_source` and `hipsycl_rewrite_includes`.
I've also added `clang-8` and `clang-8.0` to the list of clang executables that we look for.
