### PR TITLE
Implement selective rewriting of includes

### DIFF
--- a/bin/syclcc
+++ b/bin/syclcc
@@ -144,7 +144,8 @@ class source_file_processor:
          "-DHIPCPU_NO_OPENMP",
          "-Wno-unused-command-line-argument"]
          +self._additional_args
-         +self._config.hipsycl_common_arguments)
+         +self._config.hipsycl_common_arguments
+         +["--rewrite-include-paths="+p for p in self._config.device_header_paths])
 
       if returnvalue != 0:
         raise RuntimeError("Error while rewriting includes, aborting compilation")
@@ -484,6 +485,10 @@ class hipcpu_compiler:
 #               when building hipSYCL itself.
 #  --hipsycl-platform=<platform>  Build the program for the specified
 #               hipSYCL platform; valid values are: cuda,nvcc,rocm,cpu
+#  --restrict-device-header-path=<path>,
+#  -RDI=<path>  Restrict the paths in which include
+#               files are allowed to contain device code. Can be specified
+#               several times.
 #  --help       Print help message
 class syclcc_config:
   def __init__(self, argv):
@@ -494,6 +499,7 @@ class syclcc_config:
     self._keep_temporaries = False
     self._platform = None
     self._is_bootstrap = False
+    self._device_header_paths = []
 
     self._try_get_platform_from_env()
     self._try_get_cuda_clang_compiler_from_env()
@@ -516,6 +522,8 @@ class syclcc_config:
           raise RuntimeError("hipSYCL platform has been specified multiple times")
 
         self._platform = platform
+      elif arg.startswith("--restrict-device-header-path=") or arg.startswith("-RDI="):
+        self._device_header_paths.append(self._parse_compound_argument(arg)) 
       elif arg == "--help":
         print(""" 
 --force-alternative-compiler=<compiler>  Use the specified compiler
@@ -531,6 +539,10 @@ class syclcc_config:
                when building hipSYCL itself.
 --hipsycl-platform=<platform>  Build the program for the specified
                hipSYCL platform; valid values are: cuda,nvcc,rocm,cpu
+--restrict-device-header-path=<path>,
+-RDI=<path>    Restrict the paths in which include
+               files are allowed to contain device code. Can be specified
+               several times.
 --help Print help message """)
         sys.exit(0)
       else:
@@ -625,6 +637,10 @@ class syclcc_config:
   @property
   def hipsycl_lib_path(self):
     return os.path.join(self.hipsycl_install_path,"lib")
+
+  @property
+  def device_header_paths(self):
+    return self._device_header_paths
 
   @property
   def hipsycl_common_arguments(self):    

--- a/install/docker/CUDA/Dockerfile
+++ b/install/docker/CUDA/Dockerfile
@@ -10,7 +10,7 @@ RUN echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-8 main" >> /etc/
 RUN echo "deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic-8 main" >> /etc/apt/sources.list.d/llvm.list
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 RUN apt-get update
-RUN apt-get install -y git llvm-6.0-dev llvm-6.0 clang-6.0 cmake libboost-dev clang-6.0-dev python3 libclang-6.0-dev
+RUN apt-get install -y git llvm-6.0-dev llvm-6.0 clang-6.0 cmake libboost-all-dev clang-6.0-dev python3 libclang-6.0-dev
 RUN apt-get install -y libllvm8 llvm-8 llvm-8-dev llvm-8-runtime clang-8 clang-tools-8 libclang-common-8-dev libclang-8-dev libclang1-8 libomp-8-dev
 WORKDIR /tmp
 RUN git clone -b $hipsycl_branch --recurse-submodules $hipsycl_origin

--- a/install/docker/ROCm/Dockerfile
+++ b/install/docker/ROCm/Dockerfile
@@ -5,7 +5,7 @@ ARG hipsycl_origin=https://github.com/illuhad/hipSYCL
 ENV hipsycl_branch=$hipsycl_branch
 ENV hipsycl_origin=$hipsycl_origin
 RUN sudo apt-get update
-RUN sudo apt-get install -y python3 libclang-6.0-dev clang-6.0 llvm-6.0-dev libboost-dev gcc
+RUN sudo apt-get install -y python3 libclang-6.0-dev clang-6.0 llvm-6.0-dev libboost-all-dev gcc
 WORKDIR /tmp
 RUN git clone -b $hipsycl_branch --recurse-submodules $hipsycl_origin
 RUN mkdir /tmp/build

--- a/install/singularity/hipsycl-cuda.def
+++ b/install/singularity/hipsycl-cuda.def
@@ -8,7 +8,7 @@ echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-8 main" >> /etc/apt/
 echo "deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic-8 main" >> /etc/apt/sources.list.d/llvm.list
 wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 apt-get update
-apt-get install -y git llvm-6.0-dev llvm-6.0 clang-6.0 cmake libboost-dev clang-6.0-dev python3 libclang-6.0-dev 
+apt-get install -y git llvm-6.0-dev llvm-6.0 clang-6.0 cmake libboost-all-dev clang-6.0-dev python3 libclang-6.0-dev 
 apt-get install -y libllvm8 llvm-8 llvm-8-dev llvm-8-runtime clang-8 clang-tools-8 libclang-common-8-dev libclang-8-dev libclang1-8 libomp-8-dev
 git clone --recurse-submodules https://github.com/illuhad/hipSYCL
 mkdir build

--- a/install/singularity/hipsycl-rocm.def
+++ b/install/singularity/hipsycl-rocm.def
@@ -3,7 +3,7 @@ From: rocm/rocm-terminal
 
 %post
 apt-get update
-apt-get install -y python3 libclang-6.0-dev clang-6.0 llvm-6.0-dev libboost-dev gcc
+apt-get install -y python3 libclang-6.0-dev clang-6.0 llvm-6.0-dev libboost-all-dev gcc
 git clone --recurse-submodules https://github.com/illuhad/hipSYCL
 cd hipSYCL
 mkdir build

--- a/src/hipsycl_rewrite_includes/CMakeLists.txt
+++ b/src/hipsycl_rewrite_includes/CMakeLists.txt
@@ -3,7 +3,7 @@ project(hipsycl_rewrite_includes)
 
 find_package(LLVM REQUIRED CONFIG)
 #find_package(Clang REQUIRED)
-find_package(Boost REQUIRED)
+find_package(Boost REQUIRED COMPONENTS filesystem)
 
 get_filename_component(CLANG_BINARY_PREFIX ${CLANG_EXECUTABLE_PATH} DIRECTORY)
 
@@ -42,7 +42,8 @@ target_link_libraries(hipsycl_rewrite_includes
   clangTooling
   clangRewrite
   clangRewriteFrontend
-  clangASTMatchers)
+  clangASTMatchers
+  ${Boost_LIBRARIES})
 
 install(TARGETS hipsycl_rewrite_includes
         RUNTIME DESTINATION bin/)

--- a/src/hipsycl_rewrite_includes/HipsyclRewriteIncludes.cpp
+++ b/src/hipsycl_rewrite_includes/HipsyclRewriteIncludes.cpp
@@ -34,6 +34,7 @@
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/TextDiagnosticPrinter.h"
 #include "InclusionRewriter.hpp"
+#include "RewriteSelector.hpp"
 #include "clang/Tooling/Tooling.h"
 #include "clang/Tooling/CommonOptionsParser.h"
 #include "clang/Frontend/PreprocessorOutputOptions.h"
@@ -115,7 +116,23 @@ int main(int argc, const char** argv)
   ArgumentsAdjuster adjuster =
       [](const CommandLineArguments& args,StringRef) -> CommandLineArguments
   {
-    CommandLineArguments modifiedArgs = args;
+    CommandLineArguments modifiedArgs;
+
+    for(const auto& arg : args)
+    {
+      if(arg.find("--rewrite-include-paths=")==0)
+      {
+        auto whitelistedPath = arg.substr(std::string("--rewrite-include-paths=").size());
+        
+        hipsycl::transform::RewriteSelectorWhitelist::get().addToWhitelist(whitelistedPath);
+        hipsycl::transform::RewriteSelectorWhitelist::get().enable();
+      }
+      else
+      {
+        modifiedArgs.push_back(arg);
+      }
+    }
+
 
     modifiedArgs.push_back("-D__HIPSYCL_TRANSFORM__");
 

--- a/src/hipsycl_rewrite_includes/RewriteSelector.hpp
+++ b/src/hipsycl_rewrite_includes/RewriteSelector.hpp
@@ -30,6 +30,8 @@
 
 #include <boost/filesystem.hpp>
 
+#include "CL/sycl/detail/debug.hpp"
+
 #include <iostream>
 namespace hipsycl {
 namespace transform {
@@ -54,9 +56,9 @@ public:
     if(!isActivated)
       return true;
 
-    for(const auto& p : whiteList)
+    for(const auto& dir : whiteList)
     {
-      if(pathContainsFile(p, path))
+      if(pathContainsFile(dir, path))
         return true;
     }
 
@@ -134,6 +136,14 @@ public:
 #endif
 
     auto headerName = mgr.getFileEntryForID(includedId)->getName();
+    if(boost::filesystem::path{headerName}.is_relative())
+    {
+      HIPSYCL_DEBUG_WARNING
+          << "hipsycl_rewrite_includes: Encountered "
+          << "relative include path " << std::string{headerName}
+          << ", this may lead to incorrect inlining of includes "
+          << "if --rewrite-include-paths is used." << std::endl;
+    }
 
     // Don't rewrite the standard library headers
     if(FileType == clang::SrcMgr::CharacteristicKind::C_System ||

--- a/src/hipsycl_transform_source/CompilationTargetAnnotator.hpp
+++ b/src/hipsycl_transform_source/CompilationTargetAnnotator.hpp
@@ -131,6 +131,8 @@ private:
       _synonymousDecls;
 
   std::unordered_map<const clang::Decl*, bool> _containsUnresolvedCalls;
+
+  unsigned _warningAttemptedExternalModificationID;
 };
 
 }


### PR DESCRIPTION
This implements manual selection of paths in which header files are rewritten, as discussed in issue #20. By default, everything is rewritten (as is currently the case). If `-RDI=<path>` or `--restrict-device-header-path=<path>` (names of parameter are still up for debate) are passed to `syclcc`, then a whitelist is activated, `<path>` is added to the whitelist and only include files inside of `<path>` are rewritten. At the moment, this does not yet take into account filesystem links.

If `hipsycl_transform_source` wants to modify a source that is not rewritten, a warning is emitted. This is however still disabled by default, since the warning is apparently also triggered by many files of the STL and the hipSYCL runtime. Since no changes in these files should ever be necessary, this indicates that there may be some bug in `hipsycl_transform_source`, which is best investigated in a seperate issue.