### PR TITLE
Improve id and range spec conformance

### DIFF
--- a/include/CL/sycl/id.hpp
+++ b/include/CL/sycl/id.hpp
@@ -79,10 +79,20 @@ struct id {
     : _data{dim0, dim1, dim2}
   {}
 
+  /* -- common interface members -- */
+
   __host__ __device__
   id(const id<dimensions>& other)
     : _data{other._data}
   {}
+
+  bool operator==(const id<dimensions>& rhs) const {
+    return _data == rhs._data;
+  }
+
+  bool operator!=(const id<dimensions>& rhs) const {
+    return _data != rhs._data;
+  }
 
   __host__ __device__
   id(const range<dimensions> &range) {
@@ -103,10 +113,13 @@ struct id {
   }
 
   __host__ __device__
-  size_t& operator[](int dimension) const {
-    // Spec requires that this method should be const, but return
-    // a non-const reference...
-    return const_cast<size_t&>(this->_data[dimension]);
+  size_t& operator[](int dimension) {
+    return this->_data[dimension];
+  }
+
+  __host__ __device__
+  size_t operator[](int dimension) const {
+    return this->_data[dimension];
   }
 
   // Implementation of id<dimensions> operatorOP(const size_t &rhs) const;
@@ -168,7 +181,7 @@ struct id {
   // OP is: +=, -=, *=, /=, %=, <<=, >>=, &=, |=, ˆ=
 #define HIPSYCL_ID_BINARY_OP_IN_PLACE(op) \
   __host__ __device__ \
-  id<dimensions>& operator op(const id<dimensions> &rhs) const { \
+  id<dimensions>& operator op(const id<dimensions> &rhs) { \
     for(std::size_t i = 0; i < dimensions; ++i) \
       _data[i] op rhs._data[i]; \
     return *this; \
@@ -187,7 +200,7 @@ struct id {
 
 #define HIPSYCL_ID_BINARY_OP_IN_PLACE_SIZE_T(op) \
   __host__ __device__ \
-  id<dimensions>& operator op(const std::size_t &rhs) const { \
+  id<dimensions>& operator op(const std::size_t &rhs) { \
     for(std::size_t i = 0; i < dimensions; ++i) \
       _data[i] op rhs; \
     return *this; \

--- a/include/CL/sycl/range.hpp
+++ b/include/CL/sycl/range.hpp
@@ -75,6 +75,14 @@ dimensions==3 */
 
   /* -- common interface members -- */
 
+  bool operator==(const range<dimensions>& rhs) const {
+    return _data == rhs._data;
+  }
+
+  bool operator!=(const range<dimensions>& rhs) const {
+    return _data != rhs._data;
+  }
+
   __host__ __device__
   size_t get(int dimension) const {
     return _data[dimension];
@@ -82,8 +90,11 @@ dimensions==3 */
 
   __host__ __device__
   size_t &operator[](int dimension) {
-    // Spec requires that this method should be const, but return
-    // a non-const reference...
+    return _data[dimension];
+  }
+
+  __host__ __device__
+  size_t operator[](int dimension) const {
     return _data[dimension];
   }
 
@@ -154,7 +165,7 @@ dimensions==3 */
   // OP is: +=, -=, *=, /=, %=, <<=, >>=, &=, |=, ˆ=
 #define HIPSYCL_RANGE_BINARY_OP_IN_PLACE(op) \
   __host__ __device__ \
-  range<dimensions>& operator op(const range<dimensions> &rhs) const { \
+  range<dimensions>& operator op(const range<dimensions> &rhs) { \
     for(std::size_t i = 0; i < dimensions; ++i) \
       _data[i] op rhs._data[i]; \
     return *this; \
@@ -173,7 +184,7 @@ dimensions==3 */
 
 #define HIPSYCL_RANGE_BINARY_OP_IN_PLACE_SIZE_T(op) \
   __host__ __device__ \
-  range<dimensions>& operator op(const std::size_t &rhs) const { \
+  range<dimensions>& operator op(const std::size_t &rhs) { \
     for(std::size_t i = 0; i < dimensions; ++i) \
       _data[i] op rhs; \
     return *this; \
@@ -189,12 +200,6 @@ dimensions==3 */
   HIPSYCL_RANGE_BINARY_OP_IN_PLACE_SIZE_T(&=)
   HIPSYCL_RANGE_BINARY_OP_IN_PLACE_SIZE_T(|=)
   HIPSYCL_RANGE_BINARY_OP_IN_PLACE_SIZE_T(^=)
-
-  bool operator==(const range<dimensions>& other) const
-  { return _data == other._data; }
-
-  bool operator!=(const range<dimensions>& other) const
-  { return !(_data == other._data); }
 private:
   detail::device_array<size_t, dimensions> _data;
 


### PR DESCRIPTION
This updates some of the APIs of `cl::sycl::id` and `cl::sycl::range` to be in accordance with SYCL 1.2.1 revision 4. Notably this adds some missing "common interface members" for `id` (namely the `==` and `!=` operators) and fixes some of the issues surrounding `const` members returning non-const references that existed in earlier revisions of the spec.

However, the more interesting part really is the unit tests I wrote to test against these APIs. In order to be able to test 1-, 2-, and 3-dimensional variants for both `id` and `range` without having tons of duplicated code I'm making use of `BOOST_AUTO_TEST_CASE_TEMPLATE`. Some template juggling is required to make it work but I think the final solution is actually quite nice!