### PR TITLE
Fix item selection and linear id computation, improve spec conformance

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,6 +36,6 @@ add_definitions(-DHIPSYCL_DEBUG_LEVEL=${HIPSYCL_DEBUG_LEVEL})
 add_subdirectory(platform_api)
 
 add_executable(unit_tests unit_tests.cpp)
-target_include_directories(unit_tests PRIVATE ${Boost_HEADER_FILES} ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(unit_tests PRIVATE ${Boost_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(unit_tests PRIVATE ${Boost_LIBRARIES})
 

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -74,6 +74,28 @@ BOOST_AUTO_TEST_CASE(basic_parallel_for) {
   }
 }
 
+BOOST_AUTO_TEST_CASE(basic_parallel_for_with_offset) {
+  constexpr size_t num_threads = 128;
+  constexpr size_t offset = 64;
+  cl::sycl::queue queue;
+  std::vector<int> host_buf(num_threads + offset, 0);
+  cl::sycl::buffer<int, 1> buf{host_buf.data(),
+    cl::sycl::range<1>(num_threads + offset)};
+  queue.submit([&](cl::sycl::handler& cgh) {
+    auto acc = buf.get_access<cl::sycl::access::mode::write>(cgh);
+    cgh.parallel_for<class basic_parallel_for_with_offset>(
+      cl::sycl::range<1>(num_threads),
+      cl::sycl::id<1>(offset),
+      [=](cl::sycl::item<1> tid) {
+        acc[tid] = tid[0];
+      });
+  });
+  auto acc = buf.get_access<cl::sycl::access::mode::read>();
+  for(int i = 0; i < num_threads + offset; ++i) {
+    BOOST_REQUIRE(acc[i] == (i >= offset ? i : 0));
+  }
+}
+
 BOOST_AUTO_TEST_CASE(basic_parallel_for_nd) {
   constexpr size_t num_threads = 128;
   constexpr size_t group_size = 16;
@@ -523,4 +545,216 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(id_api, _dimensions, test_dimensions::type) {
   // TODO: In-place and binary operators
 }
 
+// Helper type to construct unique kernel names for all instantiations of
+// a templated test case.
+template<typename T, int dimensions>
+struct kernel_name {};
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(item_api, _dimensions, test_dimensions::type) {
+  namespace s = cl::sycl;
+  constexpr auto d = _dimensions::value;
+
+  const auto test_range = make_test_value<s::range, d>(
+    { 5 }, { 5, 7 }, { 5, 7, 11 });
+
+  // TODO: Add tests for common by-value semantics
+
+  s::queue queue;
+
+  {
+    // item::get_id and item::operator[] without offset
+
+    s::buffer<s::id<d>, d> result1{test_range};
+    s::buffer<s::id<d>, d> result2{test_range};
+    s::buffer<s::id<d>, d> result3{test_range};
+
+    queue.submit([&](s::handler& cgh) {
+      auto acc1 = result1.template get_access<s::access::mode::discard_write>(cgh);
+      auto acc2 = result2.template get_access<s::access::mode::discard_write>(cgh);
+      auto acc3 = result3.template get_access<s::access::mode::discard_write>(cgh);
+      cgh.parallel_for<kernel_name<class item_get_id, d>>(test_range,
+        [=](const s::item<d> item) {
+          {
+            acc1[item] = item.get_id();
+          }
+          {
+            auto id2 = item.get_id();
+            if(d >= 1) id2[0] = item.get_id(0);
+            if(d >= 2) id2[1] = item.get_id(1);
+            if(d == 3) id2[2] = item.get_id(2);
+            acc2[item] = id2;
+          }
+          {
+            auto id3 = item.get_id();
+            if(d >= 1) id3[0] = item.get_id(0);
+            if(d >= 2) id3[1] = item.get_id(1);
+            if(d == 3) id3[3] = item.get_id(2);
+            acc3[item] = id3;
+          }
+        });
+      });
+
+    auto acc1 = result1.template get_access<s::access::mode::read>();
+    auto acc2 = result2.template get_access<s::access::mode::read>();
+    auto acc3 = result3.template get_access<s::access::mode::read>();
+    for(size_t i = 0; i < test_range[0]; ++i) {
+      for(size_t j = 0; j < (d >= 2 ? test_range[1] : 1); ++j) {
+        for(size_t k = 0; k < (d == 3 ? test_range[2] : 1); ++k) {
+          const auto id = make_test_value<s::id, d>({i}, {i, j}, {i, j, k});
+          assert_array_equality(acc1[id], id);
+          assert_array_equality(acc2[id], id);
+          assert_array_equality(acc3[id], id);
+        }
+      }
+    }
+  }
+  {
+    // item::get_id and item::operator[] with offset
+
+    // Make offset a range as it's easier to handle (and can be converted to id)
+    const auto test_offset = make_test_value<s::range, d>(
+      { 2 }, { 2, 3 }, { 2, 3, 5 });
+
+    s::buffer<s::id<d>, d> result1{test_range + test_offset};
+    s::buffer<s::id<d>, d> result2{test_range + test_offset};
+    s::buffer<s::id<d>, d> result3{test_range + test_offset};
+
+    queue.submit([&](s::handler& cgh) {
+      auto acc1 = result1.template get_access<s::access::mode::discard_write>(cgh);
+      auto acc2 = result2.template get_access<s::access::mode::discard_write>(cgh);
+      auto acc3 = result3.template get_access<s::access::mode::discard_write>(cgh);
+      cgh.parallel_for<kernel_name<class item_get_id_offset, d>>(test_range,
+        s::id<d>(test_offset), [=](const s::item<d> item) {
+          {
+            acc1[item] = item.get_id();
+          }
+          {
+            auto id2 = item.get_id();
+            if(d >= 1) id2[0] = item.get_id(0);
+            if(d >= 2) id2[1] = item.get_id(1);
+            if(d == 3) id2[2] = item.get_id(2);
+            acc2[item] = id2;
+          }
+          {
+            auto id3 = item.get_id();
+            if(d >= 1) id3[0] = item.get_id(0);
+            if(d >= 2) id3[1] = item.get_id(1);
+            if(d == 3) id3[3] = item.get_id(2);
+            acc3[item] = id3;
+          }
+        });
+    });
+
+    auto acc1 = result1.template get_access<s::access::mode::read>();
+    auto acc2 = result2.template get_access<s::access::mode::read>();
+    auto acc3 = result3.template get_access<s::access::mode::read>();
+    for(size_t i = test_offset[0]; i < test_range[0]; ++i) {
+      const auto ja = d >= 2 ? test_offset[1] : 0;
+      const auto jb = d >= 2 ? test_range[1] + ja : 1;
+      for(size_t j = ja; j < jb; ++j) {
+        const auto ka = d == 3 ? test_offset[2] : 0;
+        const auto kb = d == 3 ? test_range[2] + ka : 1;
+        for(size_t k = ka; k < kb; ++k) {
+          const auto id = make_test_value<s::id, d>({i}, {i, j}, {i, j, k});
+          assert_array_equality(acc1[id], id);
+          assert_array_equality(acc2[id], id);
+          assert_array_equality(acc3[id], id);
+        }
+      }
+    }
+  }
+  {
+    // item::get_range
+
+    s::buffer<s::range<d>, d> result1{test_range};
+    s::buffer<s::range<d>, d> result2{test_range};
+
+    queue.submit([&](s::handler& cgh) {
+      auto acc1 = result1.template get_access<s::access::mode::discard_write>(cgh);
+      auto acc2 = result2.template get_access<s::access::mode::discard_write>(cgh);
+      cgh.parallel_for<kernel_name<class item_get_range, d>>(test_range,
+        [=](const s::item<d> item) {
+          {
+            acc1[item] = item.get_range();
+          }
+          {
+            auto range2 = item.get_range();
+            if(d >= 1) range2[0] = item.get_range(0);
+            if(d >= 2) range2[1] = item.get_range(1);
+            if(d == 3) range2[2] = item.get_range(2);
+            acc2[item] = range2;
+          }
+        });
+      });
+
+    auto acc1 = result1.template get_access<s::access::mode::read>();
+    auto acc2 = result2.template get_access<s::access::mode::read>();
+    for(size_t i = 0; i < test_range[0]; ++i) {
+      for(size_t j = 0; j < (d >= 2 ? test_range[1] : 1); ++j) {
+        for(size_t k = 0; k < (d == 3 ? test_range[2] : 1); ++k) {
+          const auto id = make_test_value<s::id, d>({i}, {i, j}, {i, j, k});
+          assert_array_equality(acc1[id], test_range);
+          assert_array_equality(acc2[id], test_range);
+        }
+      }
+    }
+  }
+  {
+    // item::get_offset
+
+    // Make offset a range as it's easier to handle (and can be converted to id)
+    const auto test_offset = make_test_value<s::range, d>(
+      { 2 }, { 2, 3 }, { 2, 3, 5 });
+
+    s::buffer<s::id<d>, d> result{test_range + test_offset};
+
+    queue.submit([&](s::handler& cgh) {
+      auto acc = result.template get_access<s::access::mode::discard_write>(cgh);
+      cgh.parallel_for<kernel_name<class item_get_offset, d>>(test_range,
+        s::id<d>(test_offset), [=](const s::item<d> item) {
+          acc[item] = item.get_offset();
+        });
+    });
+
+    auto acc = result.template get_access<s::access::mode::read>();
+    for(size_t i = test_offset[0]; i < test_range[0]; ++i) {
+      const auto ja = d >= 2 ? test_offset[1] : 0;
+      const auto jb = d >= 2 ? test_range[1] + ja : 1;
+      for(size_t j = ja; j < jb; ++j) {
+        const auto ka = d == 3 ? test_offset[2] : 0;
+        const auto kb = d == 3 ? test_range[2] + ka : 1;
+        for(size_t k = ka; k < kb; ++k) {
+          const auto id = make_test_value<s::id, d>({i}, {i, j}, {i, j, k});
+          assert_array_equality(acc[id], s::id<d>(test_offset));
+        }
+      }
+    }
+  }
+  {
+    // Conversion operator from item<d, false> to item<d, true>
+
+    s::buffer<s::id<d>, d> result{test_range};
+
+    queue.submit([&](s::handler& cgh) {
+      auto acc = result.template get_access<s::access::mode::discard_write>(cgh);
+      cgh.parallel_for<kernel_name<class item_conversion, d>>(test_range,
+        [=](const s::item<d> item) {
+          acc[item] = item.get_offset();
+        });
+    });
+
+    const auto empty_offset = make_test_value<s::id, d>({0}, {0, 0}, {0, 0, 0});
+    auto acc = result.template get_access<s::access::mode::read>();
+    for(size_t i = 0; i < test_range[0]; ++i) {
+      for(size_t j = 0; j < (d >= 2 ? test_range[1] : 1); ++j) {
+        for(size_t k = 0; k < (d == 3 ? test_range[2] : 1); ++k) {
+          const auto id = make_test_value<s::id, d>({i}, {i, j}, {i, j, k});
+          assert_array_equality(acc[id], empty_offset);
+        }
+      }
+    }
+  }
+}
+
 BOOST_AUTO_TEST_SUITE_END() // NOTE: Make sure not to add anything below this line
+


### PR DESCRIPTION
This addresses two related but distinct issues with the `item` class and also improves its API spec conformance.

The first thing this fixes is the way work items are selected for the user provided kernel functor whenever the global size is not a multiple of the default work group size (e.g. 16/16 for 2D kernels). Previously these were selected/discarded based on their linear id compared to the `range::size()` of the global size. While this works fine for 1D kernels it causes issues for 2D/3D kernels where the items provided to the user kernel can have coordinates that lie outside the requested global size. With this change the decision is now based on a per-dimension comparison, like you already have been using for kernels with an offset.

The second change affects the way `item::get_linear_id()` is computed. Previously, this computation was based on a global size that was determined on-the-fly using `hipBlockIdx_*`, `hipBlockDim_*` and `hipThreadIdx_*`. However, even after selecting the correct items (fixing any potentially issues with `hipThreadIdx_*`) the default work group size would always be used through `hipBlockDim_*`, which of course can lead to wrong results when, again, the global size is not a multiple of that. I've fixed this by storing the actual global size provided by the user within `detail::item_impl`, using that for the linear index computation instead.

I haven't looked into the other dispatch methods (i.e., `nd_item` and so on) for whether similar issues exist there as well, but since the user has to specify the work group size manually (and the global size has to be a multiple of it), I suspect there is no problem.

Lastly I've made some minor improvements to the `item` API, again bringing it more in line with SYCL 1.2.1 revision 4. Most notably the subscript operator now correctly includes the item offset (if any), which I understand wasn't previously possible due to the (now dropped) requirement of returning a reference, in combination with the zero-overhead storage of the offset.

---

I've also snuck in a small change that fixes the CMake includes variable for Boost (i.e., `Boost_INCLUDE_DIRS` - no idea how I previously came up with `Boost_HEADER_FILES`).