### PR TITLE
Add basic support for explicit copy operations

### DIFF
--- a/include/CL/sycl/accessor.hpp
+++ b/include/CL/sycl/accessor.hpp
@@ -51,6 +51,12 @@ class buffer;
 
 class handler;
 
+template<typename dataT, int dimensions,
+         access::mode accessmode,
+         access::target accessTarget,
+         access::placeholder isPlaceholder>
+class accessor;
+
 namespace detail {
 namespace buffer {
 
@@ -91,6 +97,22 @@ void* obtain_device_access(buffer_ptr buff,
                            sycl::handler& cgh,
                            access::mode access_mode);
 
+template<typename dataT, int dimensions,
+         access::mode accessmode,
+         access::target accessTarget = access::target::global_buffer,
+         access::placeholder isPlaceholder = access::placeholder::false_t>
+sycl::range<dimensions> get_buffer_range(const sycl::accessor<dataT, dimensions,
+  accessmode, accessTarget, isPlaceholder>&);
+
+template<typename dataT, int dimensions,
+         access::mode accessmode,
+         access::target accessTarget = access::target::global_buffer,
+         access::placeholder isPlaceholder = access::placeholder::false_t>
+size_t get_pointer_offset(const sycl::accessor<dataT, dimensions,
+  accessmode, accessTarget, isPlaceholder>& acc)
+{
+  return detail::linear_id<dimensions>::get(acc.get_offset(), get_buffer_range(acc));
+}
 
 } // accessor
 
@@ -171,7 +193,9 @@ template<typename dataT, int dimensions,
          access::placeholder isPlaceholder = access::placeholder::false_t>
 class accessor : public detail::accessor_base
 {
-
+  friend range<dimensions> detail::accessor::get_buffer_range<dataT, dimensions,
+    accessmode, accessTarget, isPlaceholder>(
+    const sycl::accessor<dataT, dimensions, accessmode, accessTarget, isPlaceholder>&);
 public:
   using value_type = dataT;
   using reference = dataT &;
@@ -242,6 +266,7 @@ access::placeholder::true_t && (accessTarget == access::target::global_buffer
     {
       this->init_placeholder_accessor(bufferRef);
     }
+    _range = _buffer_range;
   }
 
   /* Available only when: (isPlaceholder == access::placeholder::false_t &&
@@ -259,6 +284,7 @@ access::target::constant_buffer)) && dimensions > 0 */
     : detail::accessor_base{detail::buffer::get_buffer_impl(bufferRef)}
   {
     this->init_device_accessor(bufferRef, commandGroupHandlerRef);
+    _range = _buffer_range;
   }
 
   /// Creates an accessor for a partial range of the buffer, described by an offset
@@ -292,6 +318,8 @@ access::target::constant_buffer)) && dimensions > 0 */
     {
       this->init_placeholder_accessor(bufferRef);
     }
+    _range = accessRange;
+    _offset = accessOffset;
   }
 
   /* Available only when: (isPlaceholder == access::placeholder::false_t &&
@@ -310,13 +338,17 @@ access::target::constant_buffer)) && dimensions > 0 */
     : detail::accessor_base{detail::buffer::get_buffer_impl(bufferRef)}
   {
     this->init_device_accessor(bufferRef, commandGroupHandlerRef);
+    _range = accessRange;
+    _offset = accessOffset;
   }
 
   __host__ __device__
   accessor(const accessor& other)
     : detail::accessor_base{other},
       _ptr{other._ptr},
-      _range{other._range}
+      _buffer_range{other._buffer_range},
+      _range{other._range},
+      _offset{other._offset}
   {}
 
   __host__ __device__
@@ -324,7 +356,9 @@ access::target::constant_buffer)) && dimensions > 0 */
   {
     detail::accessor_base::operator=(other);
     _ptr = other._ptr;
+    _buffer_range = other._buffer_range;
     _range = other._range;
+    _offset = other._offset;
     return *this;
   }
 
@@ -369,10 +403,9 @@ access::target::constant_buffer)) && dimensions > 0 */
   template<int D = dimensions,
            typename = std::enable_if_t<(D > 0)>>
   __host__ __device__
-  range<dimensions> get_offset() const
+  id<dimensions> get_offset() const
   {
-    // ToDo: Properly implement access offsets
-    return range<dimensions>{};
+    return _offset;
   }
   /* Available only when: (accessMode == access::mode::write || accessMode ==
 access::mode::read_write || accessMode == access::mode::discard_write ||
@@ -403,8 +436,7 @@ accessMode == access::mode::discard_read_write) && dimensions > 0) */
   __host__ __device__
   dataT &operator[](id<dimensions> index) const
   {
-
-    return _ptr[detail::linear_id<dimensions>::get(index, _range)];
+    return _ptr[detail::linear_id<dimensions>::get(index, _buffer_range)];
   }
 
   /* Available only when: (accessMode == access::mode::write || accessMode ==
@@ -441,7 +473,7 @@ accessMode == access::mode::discard_read_write) && dimensions == 1) */
            typename = std::enable_if_t<(D > 0) && (M == access::mode::read)>>
   __host__ __device__
   dataT operator[](id<dimensions> index) const
-  { return _ptr[detail::linear_id<dimensions>::get(index, _range)]; }
+  { return _ptr[detail::linear_id<dimensions>::get(index, _buffer_range)]; }
 
   /* Available only when: accessMode == access::mode::read && dimensions == 1 */
   template<int D = dimensions,
@@ -472,6 +504,7 @@ accessMode == access::mode::discard_read_write) && dimensions == 1) */
     // Create sub accessor for slice at _ptr[index][...]
     accessor<dataT, dimensions-1, accessmode, accessTarget, isPlaceholder> sub_accessor;
     sub_accessor._range = detail::range::omit_first_dimension(this->_range);
+    sub_accessor._buffer_range = _buffer_range;
     sub_accessor._ptr = this->_ptr + index * sub_accessor._range.size();
 
     return sub_accessor;
@@ -482,7 +515,7 @@ accessMode == access::mode::discard_read_write) && dimensions == 1) */
            typename = std::enable_if_t<T==access::target::host_buffer>>
   dataT *get_pointer() const
   {
-    return const_cast<dataT*>(this->_ptr);
+    return const_cast<dataT*>(_ptr);
   }
 
   /* Available only when: accessTarget == access::target::global_buffer */
@@ -491,7 +524,7 @@ accessMode == access::mode::discard_read_write) && dimensions == 1) */
   __host__ __device__
   global_ptr<dataT> get_pointer() const
   {
-    return global_ptr<dataT>{_ptr};
+    return global_ptr<dataT>{const_cast<dataT*>(_ptr)};
   }
 
   /* Available only when: accessTarget == access::target::constant_buffer */
@@ -500,7 +533,7 @@ accessMode == access::mode::discard_read_write) && dimensions == 1) */
   __host__ __device__
   constant_ptr<dataT> get_pointer() const
   {
-    return constant_ptr<dataT>{_ptr};
+    return constant_ptr<dataT>{const_cast<dataT*>(_ptr)};
   }
 private:
   template<class Buffer_type>
@@ -513,7 +546,7 @@ private:
                                                  commandGroupHandlerRef,
                                                  accessmode));
 
-    this->_range = detail::buffer::get_buffer_range(bufferRef);
+    this->_buffer_range = detail::buffer::get_buffer_range(bufferRef);
   }
 
   template<class Buffer_type>
@@ -524,7 +557,7 @@ private:
           detail::accessor::obtain_host_access(buff,
                                                accessmode));
 
-    this->_range = detail::buffer::get_buffer_range(bufferRef);
+    this->_buffer_range = detail::buffer::get_buffer_range(bufferRef);
   }
 
   template<class Buffer_type>
@@ -533,14 +566,16 @@ private:
     detail::buffer_ptr buff = detail::buffer::get_buffer_impl(bufferRef);
 
     this->_ptr = reinterpret_cast<pointer_type>(buff->get_buffer_ptr());
-    this->_range = detail::buffer::get_buffer_range(bufferRef);
+    this->_buffer_range = detail::buffer::get_buffer_range(bufferRef);
   }
 
   __host__ __device__
   accessor(){}
 
-  range<dimensions> _range;
   pointer_type _ptr;
+  range<dimensions> _buffer_range;
+  range<dimensions> _range;
+  id<dimensions> _offset;
 };
 
 /// Accessor specialization for local memory
@@ -685,6 +720,21 @@ private:
   const range<dimensions> _num_elements;
 };
 
+namespace detail {
+namespace accessor {
+
+template<typename dataT, int dimensions,
+         access::mode accessmode,
+         access::target accessTarget,
+         access::placeholder isPlaceholder>
+sycl::range<dimensions> get_buffer_range(const sycl::accessor<dataT, dimensions,
+  accessmode, accessTarget, isPlaceholder>& acc)
+{
+  return acc._buffer_range;
+}
+
+}
+}
 
 } // sycl
 } // cl

--- a/include/CL/sycl/detail/util.hpp
+++ b/include/CL/sycl/detail/util.hpp
@@ -1,0 +1,47 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2018, 2019 Aksel Alpay and contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#ifndef HIPSYCL_UTIL_HPP
+#define HIPSYCL_UTIL_HPP
+
+namespace cl {
+namespace sycl {
+namespace detail {
+
+template <typename T>
+T* get_raw_pointer(T* ptr) { return ptr; }
+
+template <typename WrappedPtr>
+auto get_raw_pointer(const WrappedPtr& ptr) { return ptr.get(); }
+
+} // namespace detail
+} // namespace sycl
+} // namespace cl
+
+#endif
+

--- a/include/CL/sycl/range.hpp
+++ b/include/CL/sycl/range.hpp
@@ -243,6 +243,16 @@ static sycl::range<1> omit_first_dimension(const sycl::range<2>& r)
   return sycl::range<1>{r.get(1)};
 }
 
+template <int dimsOut, int dimsIn>
+sycl::range<dimsOut> range_cast(const sycl::range<dimsIn>& other)
+{
+  sycl::range<dimsOut> result;
+  for(size_t o = 0; o < dimsOut; ++o) {
+    result[o] = o < dimsIn ? other[o] : 1;
+  }
+  return result;
+}
+
 }
 }
 

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -816,5 +816,176 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(item_api, _dimensions, test_dimensions::type) {
   }
 }
 
+BOOST_AUTO_TEST_CASE_TEMPLATE(explicit_buffer_copy_host_ptr, _dimensions,
+  test_dimensions::type) {
+  namespace s = cl::sycl;
+  constexpr auto d = _dimensions::value;
+
+  const auto buf_size = make_test_value<s::range, d>(
+    { 64 }, { 64, 96 }, { 64, 96, 48 });
+
+  std::vector<size_t> host_buf_source(buf_size.size());
+  for(size_t i = 0; i < buf_size[0]; ++i) {
+    const auto jb = (d >= 2 ? buf_size[1] : 1);
+    for(size_t j = 0; j < jb; ++j) {
+      const auto kb = (d == 3 ? buf_size[2] : 1);
+      for(size_t k = 0; k < kb; ++k) {
+        const size_t linear_id = i * jb * kb + j * kb + k;
+        host_buf_source[linear_id] = linear_id * 2;
+      }
+    }
+  }
+
+  cl::sycl::queue queue;
+  cl::sycl::buffer<size_t, d> buf{buf_size};
+
+  queue.submit([&](cl::sycl::handler& cgh) {
+    auto acc = buf.template get_access<cl::sycl::access::mode::discard_write>(cgh);
+    cgh.copy(host_buf_source.data(), acc);
+  });
+
+  queue.submit([&](cl::sycl::handler& cgh) {
+    auto acc = buf.template get_access<cl::sycl::access::mode::read_write>(cgh);
+    cgh.parallel_for<kernel_name<class explicit_buffer_copy_host_ptr_mul3, d>>(
+      buf_size, [=](cl::sycl::item<d> item) {
+        acc[item] = acc[item] * 3;
+      });
+  });
+
+  std::shared_ptr<size_t> host_buf_result(new size_t[buf_size.size()],
+    std::default_delete<size_t[]>());
+  queue.submit([&](cl::sycl::handler& cgh) {
+    auto acc = buf.template get_access<cl::sycl::access::mode::read>(cgh);
+    cgh.copy(acc, host_buf_result);
+  }).wait();
+
+  for(size_t i = 0; i < buf_size[0]; ++i) {
+    const auto jb = (d >= 2 ? buf_size[1] : 1);
+    for(size_t j = 0; j < jb; ++j) {
+      const auto kb = (d == 3 ? buf_size[2] : 1);
+      for(size_t k = 0; k < kb; ++k) {
+        const size_t linear_id = i * jb * kb + j * kb + k;
+        BOOST_REQUIRE(host_buf_result.get()[linear_id] == linear_id * 6);
+      }
+    }
+  }
+}
+
+template<int d, typename callback>
+void run_two_accessors_copy_test(const callback& copy_cb) {
+  namespace s = cl::sycl;
+
+  const auto src_buf_size = make_test_value<s::range, d>(
+    { 64 }, { 64, 96 }, { 64, 96, 48 });
+  const auto dst_buf_size = make_test_value<s::range, d>(
+    { 32 }, { 32, 16 }, { 32, 16, 24 });
+  const auto src_offset = make_test_value<s::id, d>(
+    { 24 }, { 24, 70 }, { 24, 70, 12 });
+  const auto dst_offset = make_test_value<s::range, d>(
+    { 8 }, { 8, 10 }, { 8, 10, 16 });
+  const auto copy_range = dst_buf_size - dst_offset;
+
+  s::buffer<s::id<d>, d> src_buf{src_buf_size};
+  s::buffer<s::id<d>, d> dst_buf{dst_buf_size};
+
+  // Initialize buffers using host accessors
+  {
+    auto src_acc = src_buf.template get_access<s::access::mode::discard_write>();
+    auto dst_acc = dst_buf.template get_access<s::access::mode::discard_write>();
+
+    for(size_t i = 0; i < src_buf_size[0]; ++i) {
+      for(size_t j = 0; j < (d >= 2 ? src_buf_size[1] : 1); ++j) {
+        for(size_t k = 0; k < (d == 3 ? src_buf_size[2] : 1); ++k) {
+          const auto id = make_test_value<s::id, d>({ i }, { i, j }, { i, j, k });
+          src_acc[id] = id;
+        }
+      }
+    }
+  }
+
+  // Copy part of larger buffer into smaller buffer
+  s::queue queue;
+  queue.submit([&](s::handler& cgh) {
+    copy_cb(cgh, copy_range, src_buf, src_offset, dst_buf, s::id<d>(dst_offset));
+  });
+
+  // Validate results
+  {
+    auto dst_acc = dst_buf.template get_access<s::access::mode::read>();
+    for(size_t i = dst_offset[0]; i < dst_buf_size[0]; ++i) {
+      const auto ja = d >= 2 ? dst_offset[1] : 0;
+      const auto jb = d >= 2 ? dst_buf_size[1] : 1;
+      for(size_t j = ja; j < jb; ++j) {
+        const auto ka = d == 3 ? dst_offset[2] : 0;
+        const auto kb = d == 3 ? dst_buf_size[2] : 1;
+        for(size_t k = ka; k < kb; ++k) {
+          const auto id = make_test_value<s::id, d>({ i }, { i, j }, { i, j, k });
+          assert_array_equality(id - s::id<d>(dst_offset) + src_offset, dst_acc[id]);
+        }
+      }
+    }
+  }
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(explicit_buffer_copy_two_accessors_d2d,
+  _dimensions, test_dimensions::type) {
+  constexpr auto d = _dimensions::value;
+  namespace s = cl::sycl;
+  run_two_accessors_copy_test<d>([](s::handler& cgh, s::range<d> copy_range,
+    s::buffer<s::id<d>, d>& src_buf, s::id<d> src_offset,
+    s::buffer<s::id<d>, d>& dst_buf, s::id<d> dst_offset) {
+      auto src_acc = src_buf.template get_access<s::access::mode::read>(
+        cgh, copy_range, src_offset);
+      auto dst_acc = dst_buf.template get_access<s::access::mode::discard_write>(
+        cgh, copy_range, s::id<d>(dst_offset));
+      cgh.copy(src_acc, dst_acc);
+    });
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(explicit_buffer_copy_two_accessors_h2d,
+  _dimensions, test_dimensions::type) {
+  constexpr auto d = _dimensions::value;
+  namespace s = cl::sycl;
+  run_two_accessors_copy_test<d>([](s::handler& cgh, s::range<d> copy_range,
+    s::buffer<s::id<d>, d>& src_buf, s::id<d> src_offset,
+    s::buffer<s::id<d>, d>& dst_buf, s::id<d> dst_offset) {
+    auto src_acc = src_buf.template get_access<s::access::mode::read>(
+      copy_range, src_offset);
+    auto dst_acc = dst_buf.template get_access<s::access::mode::discard_write>(
+      cgh, copy_range, s::id<d>(dst_offset));
+    cgh.copy(src_acc, dst_acc);
+  });
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(explicit_buffer_copy_two_accessors_d2h,
+  _dimensions, test_dimensions::type) {
+  constexpr auto d = _dimensions::value;
+  namespace s = cl::sycl;
+  run_two_accessors_copy_test<d>([](s::handler& cgh, s::range<d> copy_range,
+    s::buffer<s::id<d>, d>& src_buf, s::id<d> src_offset,
+    s::buffer<s::id<d>, d>& dst_buf, s::id<d> dst_offset) {
+    auto src_acc = src_buf.template get_access<s::access::mode::read>(
+      cgh, copy_range, src_offset);
+    auto dst_acc = dst_buf.template get_access<s::access::mode::discard_write>(
+      copy_range, s::id<d>(dst_offset));
+    cgh.copy(src_acc, dst_acc);
+  });
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(explicit_buffer_copy_two_accessors_h2h,
+  _dimensions, test_dimensions::type) {
+  constexpr auto d = _dimensions::value;
+  namespace s = cl::sycl;
+  run_two_accessors_copy_test<d>([](s::handler& cgh, s::range<d> copy_range,
+    s::buffer<s::id<d>, d>& src_buf, s::id<d> src_offset,
+    s::buffer<s::id<d>, d>& dst_buf, s::id<d> dst_offset) {
+    auto src_acc = src_buf.template get_access<s::access::mode::read>(
+      copy_range, src_offset);
+    auto dst_acc = dst_buf.template get_access<s::access::mode::discard_write>(
+      copy_range, s::id<d>(dst_offset));
+    cgh.copy(src_acc, dst_acc);
+  });
+}
+
 BOOST_AUTO_TEST_SUITE_END() // NOTE: Make sure not to add anything below this line
 


### PR DESCRIPTION
This adds support for the most important explicit copy operations, namely transferring data between all combinations of host and device accessors for global buffers, as well as raw and shared host pointers. This means that e.g. images are not yet supported.

1D and 2D copying is supported on all platforms, while 3D copying is currently only supported on CUDA. This is because HIP currently [does not provide](https://github.com/ROCm-Developer-Tools/HIP/blob/master/docs/markdown/CUDA_Runtime_API_functions_supported_by_HIP.md) a `hipMemcpy3DAsync`. It does have a `hipMemcpy3D` which we could fall back to, however that uses a slightly different parameter struct compared to its CUDA counterpart, and as I don't have access to a working HCC setup, I couldn't test this - so I omitted it for now.

In order to support copying of subranges at arbitrary locations within source and target buffers, I also added proper handling of ranges and offsets for `accessor`. Unfortunately I didn't have time to add explicit test cases for the accessor API, however it should at least partially be covered by the new and existing test cases.

On that note, going through the spec I couldn't really determine what the exact semantics for copying between two accessors that both have an offset and a range should be. I assume (and that is what I implemented) that the first byte copied from `src` is at `src.pointer + linear_id(src.offset, src.buffer_range)`, and is written to `dest.pointer + linear_id(dest.offset, dest.buffer_range)`. Also the total number of copied elements is determined by `src.range`, which is why `dest.range` must at least be sized equally. The reason I'm confused about this is that ComputeCpp seems to be doing something different (*what* exactly I couldn't really figure out, I certainly doesn't seem 100% right -- which however could be due to the fact that I'm running their experimental PTX backend...). Since triSYCL doesn't support `copy()` yet, I couldn't verify the behavior with a third party.

In addition to that, the template parameterization given in the spec seems to have some issues, as e.g. this

```c++
template <typename T, int dim, access::mode mode, access::target tgt>
void copy(accessor<T, dim, mode, tgt> src, accessor<T, dim, mode, tgt> dest)
```
would enforce that both `src` and `dest` have the same access mode and target, which doesn't make much sense.

---

On a more technical level, I'm using `buffer_impl::register_external_access` whenever a host accessor is involved to ensure that `copy()` operations are correctly considered when determining buffer dependencies (device accessors are already covered by the existing mechanism involving `handler::_detail_add_access`). From looking at the debug output of the task graph I think this works, but please have a look to see if you can spot any issues with that.

The tests mostly focus on the overload of `copy()` that uses two accessors, as it is the most involved one. Ultimately however I tried to share as much code as possible between all variants, and especially the raw and shared pointer variants use the exact same code.

A known limitation for now is that since hipSYCL currently only tracks buffer versions for entire buffers, performing an explicit copy using a discard_* access mode into a subrange of a buffer will invalidate the entire buffer range (but that issue is not exclusive to explicit copy operations).