### PR TITLE
Fix PKGBUILDs for Arch Linux to account for current build system

### DIFF
--- a/install/archlinux/CUDA/PKGBUILD
+++ b/install/archlinux/CUDA/PKGBUILD
@@ -8,7 +8,7 @@ url="https://github.com/illuhad/hipSYCL"
 makedepends=("cmake")
 provides=("hipSYCL" "SYCL")
 license=("BSD")
-depends=("cuda-9.2" "llvm" "clang" "boost")
+depends=("cuda-9.2" "llvm" "clang" "boost" "openmp")
 
 source=('hipSYCL::git+https://github.com/illuhad/hipSYCL.git')
 

--- a/install/archlinux/CUDA/PKGBUILD
+++ b/install/archlinux/CUDA/PKGBUILD
@@ -1,6 +1,6 @@
-# Maintainer: Aksel Alpay <aksel dot alpay at uni-heidelberg dot de>
+# Maintainer: Aksel Alpay <aksel.alpay at uni-heidelberg dot de>
 pkgname=hipsycl-cuda-git
-pkgver=0.7.0
+pkgver=0.7.9
 pkgrel=1
 pkgdesc="SYCL implementation over CUDA/HIP for NVIDIA devices."
 arch=("x86_64")
@@ -8,7 +8,7 @@ url="https://github.com/illuhad/hipSYCL"
 makedepends=("cmake")
 provides=("hipSYCL" "SYCL")
 license=("BSD")
-depends=("cuda" "llvm" "clang" "boost")
+depends=("cuda-9.2" "llvm" "clang" "boost")
 
 source=('hipSYCL::git+https://github.com/illuhad/hipSYCL.git')
 
@@ -26,16 +26,23 @@ prepare() {
 }
 
 build() {
-    export HIPSYCL_PLATFORM=cuda
     mkdir -p ${srcdir}/hipSYCL/build
     cd "${srcdir}/hipSYCL/build"
-    cmake -DCMAKE_BUILD_TYPE=Release \
+    # We compile with nvcc since Arch Linux uses very new versions of CUDA
+    # which may not yet be supported by clang.
+    CXX=clang++ cmake -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_INSTALL_PREFIX=/opt/hipSYCL/CUDA \
-          -DWITH_CPU_BACKEND=ON -DWITH_CUDA_BACKEND=ON ..
+          -DWITH_CPU_BACKEND=ON -DWITH_CUDA_BACKEND=ON -DCMAKE_CXX_FLAGS="--cuda-path=/opt/cuda-9.2 -L/opt/cuda-9.2/lib64" ..
 }
 
 package() {
-    export HIPSYCL_PLATFORM=cuda
     cd "${srcdir}/hipSYCL/build"
-    VERBOSE=1 DESTDIR=${pkgdir} make install
+    CXX=clang++ VERBOSE=1 DESTDIR=${pkgdir} make install
+    
+    echo "
+hipSYCL now uses clang as CUDA compiler by default, compilation with nvcc
+may or may not work. Since clang 8 does not yet support CUDA 10.1 from Arch Linux,
+make sure to point it to an older CUDA version (up to 10.0) when compiling hipSYCL applications.
+E.g.: syclcc --cuda-path=/opt/cuda-9.2 -L/opt/cuda-9.2/lib64 ...
+    "
 }

--- a/install/archlinux/ROCm/PKGBUILD
+++ b/install/archlinux/ROCm/PKGBUILD
@@ -8,7 +8,7 @@ url="https://github.com/illuhad/hipSYCL"
 makedepends=("cmake")
 provides=("hipSYCL" "SYCL")
 license=("BSD")
-depends=("llvm" "clang" "boost")
+depends=("llvm" "clang" "boost" "openmp")
 
 source=('hipSYCL::git+https://github.com/illuhad/hipSYCL.git')
 

--- a/install/archlinux/ROCm/PKGBUILD
+++ b/install/archlinux/ROCm/PKGBUILD
@@ -1,6 +1,6 @@
-# Maintainer: Aksel Alpay <aksel dot alpay at uni-heidelberg dot de>
+# Maintainer: Aksel Alpay <aksel.alpay at uni-heidelberg dot de>
 pkgname=hipsycl-rocm-git
-pkgver=0.7.0
+pkgver=0.7.9
 pkgrel=1
 pkgdesc="SYCL implementation over CUDA/HIP for AMD devices."
 arch=("x86_64")
@@ -26,7 +26,6 @@ prepare() {
 }
 
 build() {
-    export HIPSYCL_PLATFORM=rocm
     mkdir -p ${srcdir}/hipSYCL/build
     cd "${srcdir}/hipSYCL/build"
     cmake -DCMAKE_BUILD_TYPE=Release \
@@ -35,7 +34,6 @@ build() {
 }
 
 package() {
-    export HIPSYCL_PLATFORM=rocm
     cd "${srcdir}/hipSYCL/build"
     VERBOSE=1 DESTDIR=${pkgdir} make install
 }


### PR DESCRIPTION
This fixes issue #43, updating the Arch Linux PKGBUILDs for the current state of the build system. Also taken account is the recent switch to CUDA 10.1 in Arch Linux which is not yet supported by clang 8. So, we are now using cuda 9.2 as dependency which is available in the Arch Linux AUR.

As a sidenote, I noticed that compilation of hipSYCL with nvcc seems to be broken at the moment, likely since the addition of the explicit copy API. However, I think the reason is probably the fault of general nvcc weirdness, not the recent code additions. This is best discussed in a separate issue.