### PR TITLE
Fix various minor compiler warnings

### DIFF
--- a/include/CL/sycl/accessor.hpp
+++ b/include/CL/sycl/accessor.hpp
@@ -301,10 +301,10 @@ access::target::constant_buffer)) && dimensions > 0 */
            int D = dimensions,
            std::enable_if_t<(P == access::placeholder::false_t &&
                              T == access::target::host_buffer) ||
-                            (P == access::placeholder::true_t &&
+                            ((P == access::placeholder::true_t &&
                             (T == access::target::global_buffer ||
                              T == access::target::constant_buffer)) &&
-                            (D > 0) >* = nullptr>
+                            (D > 0)) >* = nullptr>
   accessor(buffer<dataT, dimensions> &bufferRef,
            range<dimensions> accessRange,
            id<dimensions> accessOffset = {})

--- a/include/CL/sycl/context.hpp
+++ b/include/CL/sycl/context.hpp
@@ -63,8 +63,10 @@ public:
 
     _platform = deviceList.front().get_platform();
 
-    for(const auto dev : deviceList)
+    for(const auto dev : deviceList) {
+      (void)(&dev);
       assert(dev.get_platform() == _platform);
+    }
   }
 
   /* CL Interop is not supported

--- a/include/CL/sycl/detail/thread_hierarchy.hpp
+++ b/include/CL/sycl/detail/thread_hierarchy.hpp
@@ -38,32 +38,32 @@ namespace sycl {
 namespace detail {
 
 
-static __device__ size_t get_global_id_x()
+inline __device__ size_t get_global_id_x()
 {
   return hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
 }
 
-static __device__ size_t get_global_id_y()
+inline __device__ size_t get_global_id_y()
 {
   return hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
 }
 
-static __device__ size_t get_global_id_z()
+inline __device__ size_t get_global_id_z()
 {
   return hipBlockIdx_z * hipBlockDim_z + hipThreadIdx_z;
 }
 
-static __device__ size_t get_global_size_x()
+inline __device__ size_t get_global_size_x()
 {
   return hipGridDim_x * hipBlockDim_x;
 }
 
-static __device__ size_t get_global_size_y()
+inline __device__ size_t get_global_size_y()
 {
   return hipGridDim_y * hipBlockDim_y;
 }
 
-static __device__ size_t get_global_size_z()
+inline __device__ size_t get_global_size_z()
 {
   return hipGridDim_z * hipBlockDim_z;
 }
@@ -72,42 +72,42 @@ static __device__ size_t get_global_size_z()
 
 template<int dimensions>
 __device__
-static id<dimensions> get_local_id();
+id<dimensions> get_local_id();
 
 template<>
 __device__
-id<1> get_local_id<1>()
+inline id<1> get_local_id<1>()
 { return id<1>{hipThreadIdx_x}; }
 
 template<>
 __device__
-id<2> get_local_id<2>()
+inline id<2> get_local_id<2>()
 { return id<2>{hipThreadIdx_x, hipThreadIdx_y}; }
 
 template<>
 __device__
-id<3> get_local_id<3>()
+inline id<3> get_local_id<3>()
 { return id<3>{hipThreadIdx_x, hipThreadIdx_y, hipThreadIdx_z}; }
 
 template<int dimensions>
 __device__
-static id<dimensions> get_global_id();
+id<dimensions> get_global_id();
 
 template<>
 __device__
-id<1> get_global_id<1>()
+inline id<1> get_global_id<1>()
 { return id<1>{get_global_id_x()}; }
 
 template<>
 __device__
-id<2> get_global_id<2>()
+inline id<2> get_global_id<2>()
 {
   return id<2>{get_global_id_x(), get_global_id_y()};
 }
 
 template<>
 __device__
-id<3> get_global_id<3>()
+inline id<3> get_global_id<3>()
 {
   return id<3>{get_global_id_x(),
                get_global_id_y(),
@@ -116,16 +116,16 @@ id<3> get_global_id<3>()
 
 template<int dimensions>
 __device__
-static id<dimensions> get_group_id();
+id<dimensions> get_group_id();
 
 template<>
 __device__
-id<1> get_group_id<1>()
+inline id<1> get_group_id<1>()
 { return id<1>{hipBlockIdx_x}; }
 
 template<>
 __device__
-id<2> get_group_id<2>()
+inline id<2> get_group_id<2>()
 {
   return id<2>{hipBlockIdx_x,
                hipBlockIdx_y};
@@ -133,7 +133,7 @@ id<2> get_group_id<2>()
 
 template<>
 __device__
-id<3> get_group_id<3>()
+inline id<3> get_group_id<3>()
 {
   return id<3>{hipBlockIdx_x,
                hipBlockIdx_y,
@@ -142,25 +142,25 @@ id<3> get_group_id<3>()
 
 template<int dimensions>
 __device__
-static sycl::range<dimensions> get_grid_size();
+sycl::range<dimensions> get_grid_size();
 
 template<>
 __device__
-sycl::range<1> get_grid_size<1>()
+inline sycl::range<1> get_grid_size<1>()
 {
   return sycl::range<1>{hipGridDim_x};
 }
 
 template<>
 __device__
-sycl::range<2> get_grid_size<2>()
+inline sycl::range<2> get_grid_size<2>()
 {
   return sycl::range<2>{hipGridDim_x, hipGridDim_y};
 }
 
 template<>
 __device__
-sycl::range<3> get_grid_size<3>()
+inline sycl::range<3> get_grid_size<3>()
 {
   return sycl::range<3>{hipGridDim_x, hipGridDim_y, hipGridDim_z};
 }
@@ -168,38 +168,38 @@ sycl::range<3> get_grid_size<3>()
 
 template<int dimensions>
 __device__
-static sycl::range<dimensions> get_local_size();
+sycl::range<dimensions> get_local_size();
 
 template<>
 __device__
-sycl::range<1> get_local_size<1>()
+inline sycl::range<1> get_local_size<1>()
 {
   return sycl::range<1>{hipBlockDim_x};
 }
 
 template<>
 __device__
-sycl::range<2> get_local_size<2>()
+inline sycl::range<2> get_local_size<2>()
 {
   return sycl::range<2>{hipBlockDim_x, hipBlockDim_y};
 }
 
 template<>
 __device__
-sycl::range<3> get_local_size<3>()
+inline sycl::range<3> get_local_size<3>()
 {
   return sycl::range<3>{hipBlockDim_x, hipBlockDim_y, hipBlockDim_z};
 }
 
 template<int dimensions>
 __device__
-static sycl::range<dimensions> get_global_size()
+sycl::range<dimensions> get_global_size()
 {
   return get_local_size<dimensions>() * get_grid_size<dimensions>();
 }
 
 __device__
-static size_t get_global_size(int dimension)
+inline size_t get_global_size(int dimension)
 {
   switch(dimension)
   {
@@ -214,7 +214,7 @@ static size_t get_global_size(int dimension)
 }
 
 __device__
-static size_t get_grid_size(int dimension)
+inline size_t get_grid_size(int dimension)
 {
   switch (dimension)
   {
@@ -229,7 +229,7 @@ static size_t get_grid_size(int dimension)
 }
 
 __device__
-static size_t get_local_size(int dimension)
+inline size_t get_local_size(int dimension)
 {
   switch(dimension)
   {
@@ -244,7 +244,7 @@ static size_t get_local_size(int dimension)
 }
 
 __device__
-static size_t get_global_id(int dimension)
+inline size_t get_global_id(int dimension)
 {
   switch(dimension)
   {
@@ -259,7 +259,7 @@ static size_t get_global_id(int dimension)
 }
 
 __device__
-static size_t get_local_id(int dimension)
+inline size_t get_local_id(int dimension)
 {
   switch(dimension)
   {
@@ -274,7 +274,7 @@ static size_t get_local_id(int dimension)
 }
 
 __device__
-static size_t get_group_id(int dimension)
+inline size_t get_group_id(int dimension)
 {
   switch (dimension)
   {

--- a/include/CL/sycl/h_item.hpp
+++ b/include/CL/sycl/h_item.hpp
@@ -34,12 +34,12 @@ namespace cl {
 namespace sycl {
 
 template<int dimensions>
-class group;
+struct group;
 
 template <int dimensions>
 struct h_item
 {
-  friend class group<dimensions>;
+  friend struct group<dimensions>;
 
   __device__
   h_item(){}

--- a/include/CL/sycl/info/device.hpp
+++ b/include/CL/sycl/info/device.hpp
@@ -38,7 +38,7 @@ namespace cl {
 namespace sycl {
 
 template<int>
-class id;
+struct id;
 
 class platform;
 class device;

--- a/include/CL/sycl/range.hpp
+++ b/include/CL/sycl/range.hpp
@@ -232,13 +232,13 @@ namespace detail {
 namespace range {
 
 __host__ __device__
-static sycl::range<2> omit_first_dimension(const sycl::range<3>& r)
+inline sycl::range<2> omit_first_dimension(const sycl::range<3>& r)
 {
   return sycl::range<2>{r.get(1), r.get(2)};
 }
 
 __host__ __device__
-static sycl::range<1> omit_first_dimension(const sycl::range<2>& r)
+inline sycl::range<1> omit_first_dimension(const sycl::range<2>& r)
 {
   return sycl::range<1>{r.get(1)};
 }


### PR DESCRIPTION
Currently hipSYCL produces a lot of warnings when compiling with Clang 8 (without even using `-Wall`). Well, actually its not that many, but the diagnostic output Clang produces for each of them is about a page long, making it almost impossible to spot any actual issues within user code. As most of the warnings are due to a few minor issues, I just fixed them in one go.

This mostly converts a bunch of functions that were defined within headers as `static` to `inline` (which has very similar semantics from a linker perspective, but doesn't produce a bunch of "unused function" warnings).

However, there is one more really pesky warning that is not yet addressed by this: Clang complains that `warning: conversion function converting 'cl::sycl::item<3, true>' to itself will never be used`. This is particularly annoying as it not only seems to be a faulty diagnostic (the `cl::sycl::item<Dims, false>::operator item<Dims, true>` doesn't convert to itself...), but there also appears to be no (publicly documented) compiler flag for turning it off!  It certainly isn’t mentioned in the [diagnostics reference](https://clang.llvm.org/docs/DiagnosticsReference.html). I’ve actually written a script that tries to narrow it down from all 700-something flags using a binary search, but no dice.

The only way I could get rid of this warning is to split the definitions of `item<Dims, true>` and `item<Dims, false>` into separate template specializations that inherit their shared members from a common base class. This is of course a larger change and I'm not sure if you'd like to go down that route @illuhad. This also means that e.g. the `detail::item_offset_storage` would no longer be required. Let me know if you'd want me to add this to this PR as well.