### PR TITLE
Refactor item implementation

### DIFF
--- a/include/CL/sycl/h_item.hpp
+++ b/include/CL/sycl/h_item.hpp
@@ -56,7 +56,10 @@ public:
   __device__
   item<dimensions, false> get_global() const
   {
-    return item<dimensions, false>{};
+    return detail::make_item<dimensions>(
+      detail::get_global_id<dimensions>(),
+      detail::get_global_size<dimensions>()
+    );
   }
 
   __device__
@@ -78,10 +81,10 @@ public:
   __device__
   item<dimensions, false> get_physical_local() const
   {
-    return item<dimensions, false>{detail::item_impl<dimensions>{
-        detail::get_local_id<dimensions>()
-      }
-    };
+    return detail::make_item<dimensions>(
+      detail::get_local_id<dimensions>(),
+      detail::get_global_size<dimensions>()
+    );
   }
 
   __device__

--- a/include/CL/sycl/handler.hpp
+++ b/include/CL/sycl/handler.hpp
@@ -85,7 +85,8 @@ template<int dimensions, class Function>
 __global__ void parallel_for_kernel(Function f,
                                     sycl::range<dimensions> execution_range)
 {
-  item<dimensions, false> this_item{item_impl<dimensions>{execution_range}};
+  auto this_item = detail::make_item<dimensions>(
+    detail::get_global_id<dimensions>(), execution_range);
   if(item_is_in_range(this_item, execution_range, id<dimensions>{}))
     f(this_item);
 }
@@ -95,7 +96,8 @@ __global__ void parallel_for_kernel_with_offset(Function f,
                                                 sycl::range<dimensions> execution_range,
                                                 id<dimensions> offset)
 {
-  item<dimensions> this_item{item_impl<dimensions>{execution_range}, offset};
+  auto this_item = detail::make_item<dimensions>(
+    detail::get_global_id<dimensions>(), execution_range, offset);
   if(item_is_in_range(this_item, execution_range, offset))
     f(this_item);
 }


### PR DESCRIPTION
As discussed in #46, this refactors the implementation of `cl::sycl::item` to use partial template specializations over SFINAE, with the primary goal of silencing a faulty Clang diagnostic about the conversion operator from `item<dims, false>` to `item<dims, true>` never being used.

To construct items, instead of relying on a `detail::item_impl` type that is inaccessible to users, a new `detail::make_item()` can now be used.

I've also removed the global-size-only constructor (or rather, I didn't migrate it from `item_impl` to the new `item_base`), so that an `id` always has to be explicitly provided, as I think it makes for a cleaner API. New calls to `detail::get_global_id` have thus been added in `handler`.

The only thing I'm not too certain about are the changes I had to make to `h_item`. I didn't have time to delve into the semantics of these functions (and according to your comment the spec might be a bit ambiguous here anyway), however I'm pretty sure these functions haven't been getting much use either way. Case in point: Both `h_item::get_global()` and `h_item::get_physical_local()` were broken since I removed/changed the constructors they've been using in #37 (oops!). In any case, the whole parallel for hierarchical invoke stuff is in desperate need of some unit tests!