### PR TITLE
Fix nvcc compilation of libhipSYCL

### DIFF
--- a/include/CL/sycl/item.hpp
+++ b/include/CL/sycl/item.hpp
@@ -118,8 +118,10 @@ struct item<dimensions, true> : detail::item_base<dimensions>
   }
 
 private:
+  template<int d>
+  using _range = sycl::range<d>; // workaround for nvcc
   friend __device__ item<dimensions, true> detail::make_item<dimensions>(
-    const id<dimensions>&, const sycl::range<dimensions>&, const id<dimensions>&);
+    const id<dimensions>&, const _range<dimensions>&, const id<dimensions>&);
 
   __device__ item(const id<dimensions>& my_id,
     const sycl::range<dimensions>& global_size, const id<dimensions>& offset)
@@ -162,8 +164,10 @@ struct item<dimensions, false> : detail::item_base<dimensions>
   }
 
 private:
+  template<int d>
+  using _range = sycl::range<d>; // workaround for nvcc
   friend __device__ item<dimensions, false> detail::make_item<dimensions>(
-    const id<dimensions>&, const sycl::range<dimensions>&);
+    const id<dimensions>&, const _range<dimensions>&);
 
   __device__ item(const id<dimensions>& my_id,
     const sycl::range<dimensions>& global_size)


### PR DESCRIPTION
It looks like I broke the compilation of libhipSYCL using `nvcc` with #48, as apparently it has difficulties to find the `cl::sycl::range` type, even when disambiguated with the `sycl` namespace. I've added a workaround that creates an alias, then everything works. I sure love nvcc...

By the way: It would be great if something like this could also be caught by Travis (as I frankly don't try `-DUSE_NVCC=1` very often) - maybe we should add another build config?