### PR TITLE
Fix memory leak caused by shared_ptr dependency cycle

### DIFF
--- a/src/libhipSYCL/task_graph.cpp
+++ b/src/libhipSYCL/task_graph.cpp
@@ -134,6 +134,13 @@ task_graph_node::submit()
 
     _stream->activate_device();
     task_state state = _tf();
+    
+    // Remove the task functor after execution to avoid
+    // cyclic dependencies between buffer objects (that store
+    // task_graph_node_ptrs for dependency calculation) and
+    // the captured accessors
+    this->_tf = task_functor{};
+
     _submitted = true;
 
     if(state == task_state::enqueued)
@@ -158,6 +165,7 @@ task_graph_node::submit()
     // Submitted must be set to true to avoid
     // subsequent submissions
     _submitted = true;
+    this->_tf = task_functor{};
     // ToDo: Should we also consider the task as done here?
     // Or at least trigger the callback?
 


### PR DESCRIPTION
There is a cyclic `shared_ptr` dependency causing the memory leak mentioned in issue #47:

* `buffer_ptr` maintains a list of related `task_graph_node_ptr` objects in the access log for dependency calculation
* `task_graph_node_ptr` contains a closure for asynchronous execution, such as a kernel launch
* kernel launch closure will in general capture accessors
* accessors maintain a `shared_ptr` to the `buffer_ptr` to which they refer via the `accessor_tracker`.
... and the cycle (which prevents any buffer from being freed!) is complete.

This PR fixes this by resetting the closure in the `task_graph_node_ptr` to a default-constructed function object after submission, thus breaking the cycle.