### PR TITLE
Minor build fixes in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,8 @@ set(WITH_CPU_BACKEND true CACHE BOOL "Build hipSYCL with support for host execut
 cmake_policy(SET CMP0005 NEW)
 add_definitions(-DHIPSYCL_DEBUG_LEVEL=${HIPSYCL_DEBUG_LEVEL})
 
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_subdirectory(src)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,8 +70,6 @@ set(WITH_CPU_BACKEND true CACHE BOOL "Build hipSYCL with support for host execut
 cmake_policy(SET CMP0005 NEW)
 add_definitions(-DHIPSYCL_DEBUG_LEVEL=${HIPSYCL_DEBUG_LEVEL})
 
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_subdirectory(src)
 

--- a/src/libhipSYCL/CMakeLists.txt
+++ b/src/libhipSYCL/CMakeLists.txt
@@ -45,8 +45,13 @@ endif()
 
 if(WITH_ROCM_BACKEND)
   add_library(hipSYCL_rocm SHARED ${HIPSYCL_SOURCES})
+  #Try to peek if ROCM set itself through its /etc/profile.d/rocm.sh
+  set(ROCM_PATH $ENV{ROCM_PATH})
   target_compile_options(hipSYCL_rocm PRIVATE --hipsycl-platform=rocm --hipsycl-bootstrap)
   target_include_directories(hipSYCL_rocm PRIVATE ${INCLUDE_DIRS})
+  if(ROCM_PATH)
+      target_include_directories(hipSYCL_rocm PRIVATE ${ROCM_PATH}/include )
+  endif()
   target_link_libraries(hipSYCL_rocm --hipsycl-platform=rocm --hipsycl-bootstrap)
   install(TARGETS hipSYCL_rocm
           LIBRARY DESTINATION lib
@@ -61,5 +66,5 @@ if(WITH_CPU_BACKEND)
   install(TARGETS hipSYCL_cpu
           LIBRARY DESTINATION lib
           ARCHIVE DESTINATION lib/static)
-        
+
 endif()

--- a/src/libhipSYCL/CMakeLists.txt
+++ b/src/libhipSYCL/CMakeLists.txt
@@ -13,17 +13,24 @@ set(HIPSYCL_SOURCES
   task_graph.cpp
   accessor.cpp
   async_worker.cpp)
-  
+
 
 set(INCLUDE_DIRS
-  ${HIPSYCL_SOURCE_DIR}/include 
+  ${HIPSYCL_SOURCE_DIR}/include
   ${HIPSYCL_SOURCE_DIR}/contrib/hipCPU/include)
 
 if(WITH_CUDA_BACKEND)
   add_library(hipSYCL_cuda SHARED ${HIPSYCL_SOURCES})
 
   if(USE_NVCC)
+      if(NOT CMAKE_CUDA_STANDARD)
+          set (CMAKE_CUDA_STANDARD 14)
+      endif()
     set(CUDA_PLATFORM nvcc)
+    target_compile_options(hipSYCL_cuda PRIVATE --std c++${CMAKE_CUDA_STANDARD})
+    if(CMAKE_CUDA_HOST_COMPILER)
+        target_compile_options(hipSYCL_cuda PRIVATE -ccbin ${CMAKE_CUDA_HOST_COMPILER})
+    endif()
   else()
     set(CUDA_PLATFORM cuda)
   endif()


### PR DESCRIPTION
Three minor cmake fixes in hipsycl itself:

1 - Explicitly set `CMAKE_CXX_STANDARD` to 14, in case it doesn't get automagically set 

2 - Set and forwarded `CMAKE_CUDA_HOST_COMPILER` and `CMAKE_CUDA_STANDARD` to the CUDA target if building with NVCC, as those don't always get correctly inherited to match the C++ side of the build

3 - Probed the system for the `ROCM_PATH` variable and used it, if present, to add ROCM's include path to the build. I myself had always been adding the full path manually, but ROCM sets this on a file in profile.d when it install itself, so probing this env variable is an option

None of these changes should break pre-existing builds. The one that could would be no1 if the compiler doesn't support it but it seems to me SYCL doesn't even build with a standard lower than 14 due to lambda shenanigans