### PR TITLE
Enforce cxx standards in build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,10 @@ cmake_policy(SET CMP0005 NEW)
 add_definitions(-DHIPSYCL_DEBUG_LEVEL=${HIPSYCL_DEBUG_LEVEL})
 
 
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 add_subdirectory(src)
 
 

--- a/install/docker/CUDA/Dockerfile
+++ b/install/docker/CUDA/Dockerfile
@@ -20,4 +20,4 @@ ENV CXX=clang++-8
 ENV PATH=/usr/local/cuda/bin:$PATH
 ENV LIBRARY_PATH=/usr/local/cuda/lib64:$LIBRARY_PATH
 RUN cmake -DCMAKE_INSTALL_PREFIX=/usr -DWITH_CPU_BACKEND=ON -DWITH_CUDA_BACKEND=ON /tmp/hipSYCL
-RUN make install
+RUN make -j$(($(nproc) -1)) install

--- a/install/docker/ROCm/Dockerfile
+++ b/install/docker/ROCm/Dockerfile
@@ -14,6 +14,5 @@ USER root
 ENV CXX=clang++-6.0
 ENV PATH=/opt/rocm/bin:$PATH
 ENV HIPSYCL_GPU_ARCH=gfx900
-RUN cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_CXX_FLAGS="-std=c++14" -DWITH_CPU_BACKEND=ON -DWITH_ROCM_BACKEND=ON /tmp/hipSYCL
-RUN make install
-
+RUN cmake -DCMAKE_INSTALL_PREFIX=/usr -DWITH_CPU_BACKEND=ON -DWITH_ROCM_BACKEND=ON /tmp/hipSYCL
+RUN make -j$(($(nproc) -1)) install

--- a/install/singularity/hipsycl-cuda.def
+++ b/install/singularity/hipsycl-cuda.def
@@ -8,13 +8,14 @@ echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-8 main" >> /etc/apt/
 echo "deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic-8 main" >> /etc/apt/sources.list.d/llvm.list
 wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 apt-get update
-apt-get install -y git llvm-6.0-dev llvm-6.0 clang-6.0 cmake libboost-all-dev clang-6.0-dev python3 libclang-6.0-dev 
+apt-get install -y git llvm-6.0-dev llvm-6.0 clang-6.0 cmake libboost-all-dev clang-6.0-dev python3 libclang-6.0-dev
 apt-get install -y libllvm8 llvm-8 llvm-8-dev llvm-8-runtime clang-8 clang-tools-8 libclang-common-8-dev libclang-8-dev libclang1-8 libomp-8-dev
 git clone --recurse-submodules https://github.com/illuhad/hipSYCL
 mkdir build
 cd build
+export CC=clang-8
 export CXX=clang++-8
 export PATH=/usr/local/cuda/bin:$PATH
 export LIBRARY_PATH=/usr/local/cuda/lib64:$LIBRARY_PATH
-cmake -DCMAKE_INSTALL_PREFIX=/usr  -DWITH_CPU_BACKEND=ON -DWITH_CUDA_BACKEND=ON ../hipSYCL
-make install
+cmake -DCMAKE_CXX_COMPILER=clang++-8 -DCMAKE_C_COMPILER=clang-8  -DCMAKE_INSTALL_PREFIX=/usr  -DWITH_CPU_BACKEND=ON -DWITH_CUDA_BACKEND=ON ../hipSYCL
+make -j$(($(nproc) -1)) install

--- a/install/singularity/hipsycl-rocm.def
+++ b/install/singularity/hipsycl-rocm.def
@@ -8,8 +8,9 @@ git clone --recurse-submodules https://github.com/illuhad/hipSYCL
 cd hipSYCL
 mkdir build
 cd build
+export CC=clang-6.0
+export CXX=clang++-6.0
 export PATH=/opt/rocm/bin:$PATH
 export HIPSYCL_GPU_ARCH=gfx900
-export CXX=clang++-6.0
-cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_CXX_FLAGS="-std=c++14" -DWITH_CPU_BACKEND=ON -DWITH_ROCM_BACKEND=ON ..
-make install
+cmake -DCMAKE_C_COMPILER=clang-6.0 -DCMAKE_CXX_COMPILER=clang++-6.0 -DCMAKE_INSTALL_PREFIX=/usr -DWITH_CPU_BACKEND=ON -DWITH_ROCM_BACKEND=ON ..
+make -j$(($(nproc) -1)) install


### PR DESCRIPTION
This should be the correct version of that fix. Passed both docker build tests. I've also removed the now extraneous `--std=c++14` build flag from the ROCm build and used the opportunity to multithread the build in both that dockerfile and the one for CUDA

Thanks @psalz for giving me a reason to revisit every single build at work now that you've shown me CMAKE_CXX_EXTENSIONS =P