### PR TITLE
Move implementation of application members to CPP

### DIFF
--- a/include/CL/sycl/detail/application.hpp
+++ b/include/CL/sycl/detail/application.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
  *
- * Copyright (c) 2018 Aksel Alpay
+ * Copyright (c) 2018, 2019 Aksel Alpay and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,8 +31,6 @@
 #include <memory>
 
 #include "runtime.hpp"
-#include "../backend/backend.hpp"
-#include "../device.hpp"
 
 namespace cl {
 namespace sycl {
@@ -41,29 +39,11 @@ namespace detail {
 class application
 {
 public:
+  static runtime& get_hipsycl_runtime();
 
-  static runtime& get_hipsycl_runtime()
-  {
-    return *rt;
-  }
+  static task_graph& get_task_graph();
 
-  static task_graph& get_task_graph()
-  {
-    return get_hipsycl_runtime().get_task_graph();
-  }
-
-  static void reset()
-  {
-    rt.reset();
-    rt = std::make_unique<runtime>();
-#if defined(HIPSYCL_PLATFORM_CUDA) || defined(HIPSYCL_PLATFORM_HCC)
-    const auto devices = device::get_devices(info::device_type::all);
-    for(auto& d : devices) {
-      detail::set_device(d);
-      hipDeviceReset();
-    }
-#endif
-  }
+  static void reset();
 
   application() = delete;
 

--- a/src/libhipSYCL/application.cpp
+++ b/src/libhipSYCL/application.cpp
@@ -26,10 +26,35 @@
  */
 
 #include "CL/sycl/detail/application.hpp"
+#include "CL/sycl/backend/backend.hpp"
+#include "CL/sycl/device.hpp"
 
 namespace cl {
 namespace sycl {
 namespace detail {
+
+runtime& application::get_hipsycl_runtime()
+{
+  return *rt;
+}
+
+task_graph& application::get_task_graph()
+{
+  return get_hipsycl_runtime().get_task_graph();
+}
+
+void application::reset()
+{
+  rt.reset();
+  rt = std::make_unique<runtime>();
+#if defined(HIPSYCL_PLATFORM_CUDA) || defined(HIPSYCL_PLATFORM_HCC)
+  const auto devices = device::get_devices(info::device_type::all);
+  for(auto& d : devices) {
+    detail::set_device(d);
+    hipDeviceReset();
+  }
+#endif
+}
 
 std::unique_ptr<runtime> application::rt = std::make_unique<runtime>();
 


### PR DESCRIPTION
Following some additional discussion in #35 I'm moving all the inline static member functions of `application` to the CPP source file, in order to avoid potential linker issues when targeting Windows in the future.