### PR TITLE
Fix hardcoded interpreter path in shabang

### DIFF
--- a/bin/syclcc
+++ b/bin/syclcc
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 '''
  *


### PR DESCRIPTION
This PR fixes `syclcc` in environments where the `python3` interpreter isn't installed system-wide. The change should be backward compatible since `env` would still pick `/usr/bin/python3` when it is the default one.