### PR TITLE
clang plugin: Add new syclcc with clang plugin support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ FORCE)
 endif()
 
 # Make sure either hcc or nvcc can be found
-find_program(NVCC_COMPILER NAMES nvcc)
+find_package(CUDA)
 find_program(HCC_COMPILER NAMES hcc)
 find_program(CLANG_EXECUTABLE_PATH NAMES clang++-8 clang++-8.0 clang++-7.0 clang++-7 clang++-6.0 clang++-6 clang++ CACHE STRING)
 if(CLANG_EXECUTABLE_PATH MATCHES "-NOTFOUND")
@@ -33,11 +33,11 @@ endif()
 # for the existence of CUDA which is also required for clang.
 # TODO: A better approach would be to find_package(CUDA) if
 # we build with clang.
-if(NVCC_COMPILER MATCHES "-NOTFOUND")
-  set(CUDA_FOUND false)
-else()
-  set(CUDA_FOUND true)
-endif()
+#if(NVCC_COMPILER MATCHES "-NOTFOUND")
+#  set(CUDA_FOUND false)
+#else()
+#  set(CUDA_FOUND true)
+#endif()
 
 if(HCC_COMPILER MATCHES "-NOTFOUND")
   set(ROCM_FOUND false)
@@ -47,7 +47,7 @@ endif()
 
 if(WITH_CUDA_BACKEND)
   if(NOT CUDA_FOUND)
-    message(SEND_ERROR "nvcc was not found in PATH")
+    message(SEND_ERROR "CUDA was not found")
   endif()
 endif()
 if(WITH_ROCM_BACKEND)
@@ -64,6 +64,13 @@ set(WITH_CUDA_BACKEND ${CUDA_FOUND} CACHE BOOL "Build hipSYCL support for NVIDIA
 set(WITH_ROCM_BACKEND ${ROCM_FOUND} CACHE BOOL "Build hipSYCL support for AMD GPUs with ROCm")
 set(WITH_CPU_BACKEND true CACHE BOOL "Build hipSYCL with support for host execution on CPUs")
 
+if(WITH_CUDA_BACKEND)
+  set(DEFAULT_PLATFORM "cuda")
+elseif(WITH_ROCM_BACKEND)
+  set(DEFAULT_PLATFORM "rocm")
+else()
+  set(DEFAULT_PLATFORM "cpu")
+endif()
 
 #add_compile_definitions(HIPSYCL_DEBUG_LEVEL="${HIPSYCL_DEBUG_LEVEL}")
 #Use add_definitions for now for older cmake versions
@@ -73,10 +80,30 @@ add_definitions(-DHIPSYCL_DEBUG_LEVEL=${HIPSYCL_DEBUG_LEVEL})
 
 add_subdirectory(src)
 
+set(DEFAULT_GPU_ARCH "" CACHE STRING "Optional: Default GPU architecture to compile for when targeting GPUs (e.g.: sm_60 or gfx900)")
+
+set(SYCLCC_CONFIG_FILE "{
+  \"default-clang\" : \"${CLANG_EXECUTABLE_PATH}\",
+  \"default-platform\" : \"${DEFAULT_PLATFORM}\",
+  \"default-cuda-path\" : \"${CUDA_TOOLKIT_ROOT_DIR}\",
+  \"default-gpu-arch\" : \"${DEFAULT_GPU_ARCH}\",
+  \"default-cpu-cxx\" : \"${CMAKE_CXX_COMPILER}\",
+  \"default-rocm-path\" : \"/opt/rocm/\",
+  \"default-use-bootstrap-mode\" : \"false\",
+  \"default-is-dryrun\" : \"false\"
+}
+")
+
+file(WRITE "${PROJECT_BINARY_DIR}/syclcc.json" ${SYCLCC_CONFIG_FILE})
+
 
 install(DIRECTORY include/CL DESTINATION include/
         FILES_MATCHING PATTERN "*.hpp")
 install(DIRECTORY contrib/hipCPU/include/hipCPU DESTINATION include/hipSYCL/)
 
 install(DIRECTORY contrib/HIP/include/ DESTINATION include/hipSYCL/)
+
 install(PROGRAMS bin/syclcc DESTINATION bin)
+install(PROGRAMS bin/syclcc-clang DESTINATION bin)
+
+install(FILES ${PROJECT_BINARY_DIR}/syclcc.json DESTINATION etc/hipSYCL/)

--- a/bin/syclcc-clang
+++ b/bin/syclcc-clang
@@ -1,0 +1,501 @@
+#!/usr/bin/env python3
+
+'''
+ *
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2018,2019 Aksel Alpay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ '''
+
+import json
+import os
+import os.path
+import sys
+import subprocess
+
+class hipsycl_platform:
+  PURE_CPU = "cpu"
+  CUDA = "cuda"
+  HIP = "hip"
+
+class OptionNotSet(Exception):
+  def __init__(self, msg):
+    super().__init__(msg)
+
+class config_file:
+  def __init__(self, filepath):
+    self._location = filepath
+    try:
+      with open(filepath, 'r') as config_file:
+        self._data = json.load(config_file)
+        self._is_loaded = True
+    except:
+      print("Could not open config",filepath)
+      self._data = {}
+      self._is_loaded = False
+
+  @property
+  def is_loaded(self):
+    return self._is_loaded
+
+  @property
+  def location(self):
+    return self._location
+
+  def contains_key(self, key):
+    if not key in self._data:
+      return False
+    if(self._data[key].endswith("-NOTFOUND") or
+       self._data[key] == ""):
+      return False
+    return True
+
+  def get(self, key):
+    if not self.contains_key(key):
+      raise RuntimeError("Accessed missing key in config file: "+key)
+
+    return self._data[key]
+
+  def get_or_default(self, key, default_value):
+    if self.contains_key(key):
+      return self._data[key]
+    return default_value
+
+class option:
+  def __init__(self, commandline, environment, configfile, description):
+    self._commandline = commandline
+    self._environment = environment
+    self._configfile = configfile
+    self._description = description
+
+  @property
+  def commandline(self):
+    return self._commandline
+
+  @property
+  def environment(self):
+    return self._environment
+
+  @property
+  def configfile(self):
+    return self._configfile
+
+  @property
+  def description(self):
+    return self._description
+
+class syclcc_config:
+  def __init__(self, args):
+    config_file_path = os.path.abspath(
+      os.path.join(self.hipsycl_installation_path,
+                  "etc/hipSYCL/syclcc.json"))
+    self._config_file = config_file(config_file_path)
+    self._args = args
+
+    # Describes different representations of options:
+    # 1.) the corresponding command line argument
+    # 2.) the corresponding environment variable
+    # 3.) the field in the config file.
+    self._options = {
+      'platform': option("--hipsycl-platform", "HIPSYCL_PLATFORM", "default-platform",
+"""  The platform that hipSYCL should target. Valid values: 
+    * cuda: Target NVIDIA CUDA GPUs
+    * rocm: Target AMD GPUs running on the ROCm platform
+    * cpu: Target only CPUs"""),
+
+      'clang': option("--hipsycl-clang", "HIPSYCL_CLANG", "default-clang",
+"""  The path to the clang executable that should be used for compilation
+    (Note: *must* be compatible with the clang version that the 
+     hipSYCL clang plugin was compiled against!)"""),
+
+      'cuda-path': option("--hipsycl-cuda-path", "HIPSYCL_CUDA_PATH", "default-cuda-path",
+"""  The path to the CUDA toolkit installation directry"""),
+
+      'rocm-path': option("--hipsycl-rocm-path", "HIPSYCL_ROCM_PATH", "default-rocm-path",
+"""  The path to the ROCm installation directory"""),
+
+      'gpu-arch': option("--hipsycl-gpu-arch", "HIPSYCL_GPU_ARCH", "default-gpu-arch",
+"""  The GPU architecture that should be targeted when compiling for GPUs."""),
+
+      'cpu-compiler': option("--hipsycl-cpu-cxx", "HIPSYCL_CPU_CXX", "default-cpu-cxx",
+"""  The compiler that should be used when targeting only CPUs.""")
+    }
+    self._flags = {
+      'is-dryrun': option("--hipsycl-dryrun", "HIPSYCL_DRYRUN", "default-is-dryrun",
+"""  If set, only shows compilation commands that would be executed, 
+  but does not actually execute it."""),
+      'is-bootstrap': option("--hipsycl-bootstrap", "HIPSYCL_BOOTSTRAP", "default-use-bootstrap-mode",
+"""  Enter bootstrap mode. This is only required when building hipSYCL itself and 
+  should not be set by the user.""")
+    }
+
+    self._hipsycl_args = []
+    self._forwarded_args = []
+    
+    for arg in self._args:
+      if self._is_hipsycl_arg(arg):
+        self._hipsycl_args.append(arg)
+      else:
+        self._forwarded_args.append(arg)
+
+  def _is_hipsycl_arg(self, arg):
+    accepted_args = [self._options[opt].commandline for opt in self._options]
+    accepted_args += [self._flags[flag].commandline for flag in self._flags]
+    for accepted_arg in accepted_args:
+      if arg.startswith(accepted_arg + "=") or arg == accepted_arg:
+        return True
+    return False
+
+  def _parse_compound_argument(self, arg):
+    parsed_args = arg.split("=")
+    if len(parsed_args) != 2:
+      raise RuntimeError("Invalid argument: "+arg)
+    return parsed_args[1]
+
+  def print_options(self):
+    for option_name in self._options:
+      opt = self._options[option_name]
+      print(opt.commandline + "=<value>")
+      print("  [can also be set with environment variable: {}=<value>]".format(opt.environment))
+      print("  [default value provided by field '{}' in {}.]".format(opt.configfile, self._config_file.location))
+      try:
+        print("  [current value: {}]".format(self._retrieve_option(option_name)))
+      except OptionNotSet:
+        print("  [current value: NOT SET]")
+      print(opt.description)
+      print("")
+
+  def print_flags(self):
+    for flag_name in self._flags:
+      flag = self._flags[flag_name]
+      print(flag.commandline)
+      print("  [can also be set by setting environment variable {} to any value other than false|off|0 ]".format(
+        flag.environment
+      ))
+      print("  [default value provided by field '{}' in {}.]".format(flag.configfile, self._config_file.location))
+      try:
+        print("  [current value: {}]".format(self._is_flag_set(flag_name)))
+      except OptionNotSet:
+        print("  [current value: NOT SET]")
+      print(flag.description)
+      print("")
+
+  def _interpret_flag(self, flag_value):
+    v = flag_value.lower()
+    if (v == "0" or v == "off" or
+        v == "false"):
+      return False
+    return True
+      
+
+  def _is_flag_set(self, flag_name):
+    flag = self._flags[flag_name]
+    if flag.commandline in self._hipsycl_args:
+      return True
+
+    if flag.environment in os.environ:
+      env_value = os.environ[flag.environment]
+      return self._interpret_flag(env_value)
+
+    if self._config_file.contains_key(flag.configfile):
+      return self._interpret_flag(self._config_file.get(flag.configfile))
+
+    raise OptionNotSet(
+      "Could not infer value of required flag from command line argument {}, "
+      "environment variable {} or config file.".format(
+        flag.commandline, flag.environment
+    ))
+
+  def _retrieve_option(self, option_name):
+    opt = self._options[option_name]
+
+    # Try commandline first
+    for arg in self._hipsycl_args:
+      if arg.startswith(opt.commandline+"="):
+        return self._parse_compound_argument(arg)
+
+    # Try environment variables
+    if opt.environment in os.environ:
+      return os.environ[opt.environment]
+
+    # Try config file
+    if self._config_file.contains_key(opt.configfile):
+      return self._config_file.get(opt.configfile)
+
+    raise OptionNotSet("Required command line argument {} or environment variable {} not specified".format(
+            opt.commandline, opt.environment))
+
+  @property
+  def target_platform(self):
+    platform = self._retrieve_option("platform")
+
+    hip_platform_synonyms      = set(["rocm", "amd", "hip"])
+    cuda_platform_synonyms     = set(["nvidia", "cuda"])
+    pure_cpu_platform_synonyms = set(["host", "cpu", "hipcpu"])
+
+    if platform in hip_platform_synonyms:
+      return hipsycl_platform.HIP
+    elif platform in cuda_platform_synonyms:
+      return hipsycl_platform.CUDA
+    elif platform in pure_cpu_platform_synonyms:
+      return hipsycl_platform.PURE_CPU
+
+    raise RuntimeError("Invalid hipSYCL platform: "+platform)
+
+  @property
+  def target_arch(self):
+    return self._retrieve_option("gpu-arch")
+
+  @property
+  def cuda_path(self):
+    return self._retrieve_option("cuda-path")
+
+  @property
+  def rocm_path(self):
+    return self._retrieve_option("rocm-path")
+
+  @property
+  def clang_path(self):
+    return self._retrieve_option("clang")
+
+  @property
+  def pure_cpu_compiler(self):
+    return self._retrieve_option("cpu-compiler")
+
+  @property
+  def hipsycl_installation_path(self):
+    syclcc_path = os.path.dirname(os.path.realpath(__file__))
+    return os.path.join(syclcc_path, "..")
+    
+  @property
+  def forwarded_compiler_arguments(self):
+    return self._forwarded_args
+
+  @property
+  def is_bootstrap(self):
+    return self._is_flag_set("is-bootstrap")
+
+  @property
+  def is_dryrun(self):
+    try:
+      return self._is_flag_set("is-dryrun")
+    except OptionNotSet:
+      return False
+
+  def contains_linking_stage(self):
+    for arg in self.forwarded_compiler_arguments:
+      if (arg == "-E" or
+          arg == "-fsyntax-only" or
+          arg == "-S" or
+          arg == "-c"):
+        return False
+    return True
+
+  def is_pure_linking_stage(self):
+    source_file_endings = set([".cpp",".cxx",".c++",".cc",".c", ".hip", ".cu"])
+    for arg in self.forwarded_compiler_arguments:
+      if not arg.startswith("-"):
+        for ending in source_file_endings:
+          if arg.lower().endswith(ending):
+            return False
+    return True
+
+def run_or_print(command, print_only):
+  if not print_only:
+      return subprocess.call(command)
+  else:
+    print(' '.join(command))
+    return 0
+
+## clang-based compiler using the hipSYCL clang plugin for CUDA/ROCm
+class clang_plugin_compiler:
+  def __init__(self, config):
+    self._args = config.forwarded_compiler_arguments
+    self._clang = config.clang_path
+    self._contains_linking_stage = config.contains_linking_stage()
+    self._contains_compilation_stage = not config.is_pure_linking_stage()
+    self._is_dry_run = config.is_dryrun
+
+    target = config.target_platform
+    hipsycl_library_path = os.path.join(config.hipsycl_installation_path,"lib/")
+
+    if target == hipsycl_platform.CUDA:
+      self._linker_args = [
+        "-L"+os.path.join(config.cuda_path, "lib64/"),
+        "-lcudart"
+      ]
+      # In non-bootstrap mode, automatically link hipSYCL
+      if not config.is_bootstrap:
+        self._linker_args += [
+          "-L"+hipsycl_library_path,
+          "-lhipSYCL_cuda"
+        ]
+
+      self._compiler_args = ["-x", "cuda",
+                             "--cuda-gpu-arch=" + config.target_arch,
+                             "--cuda-path=" + config.cuda_path,
+                             "-I"+os.path.join(config.hipsycl_installation_path, "include/hipSYCL/")]
+    elif target == hipsycl_platform.HIP:
+      self._target = "hip"
+      
+      self._linker_args = [
+        "-L" + os.path.join(config.rocm_path, "lib"),
+        "-lhip_hcc"
+      ]
+
+      # In non-bootstrap mode, automatically link hipSYCL
+      if not config.is_bootstrap:
+        self._linker_args += [
+          "-L"+hipsycl_library_path,
+          "-lhipSYCL_rocm"
+        ]
+      
+      
+      self._compiler_args = [
+        "-x", "hip",
+        "--cuda-gpu-arch=" + config.target_arch,
+        "--hip-device-lib-path=" + os.path.join(config.rocm_path, "lib"),
+        "-I" + os.path.join(config.rocm_path, "include"),
+        "-isystem", self._get_rocm_clang_include_path(config.rocm_path)
+      ]
+
+    self._common_compiler_args = ["-std=c++14"]
+    if not config.is_bootstrap:
+      self._common_compiler_args += [
+        "-fplugin="+os.path.join(hipsycl_library_path,"libhipSYCL_clang.so"),
+        "-DHIPSYCL_CLANG",
+        "-I" + os.path.join(config.hipsycl_installation_path, "include/")
+        # We would also have to add include/hipSYCL here, but since we do
+        # not want to use the bundled HIP on ROCm, we add these includes
+        # in the platform specific section above
+      ]
+    else:
+      self._common_compiler_args += [
+        "-I"+os.path.join(config.hipsycl_installation_path, "contrib/HIP/include")
+      ]
+
+  def _get_rocm_clang_include_path(self, rocm_path):
+    base_dir = os.path.join(rocm_path, "hcc/lib/clang")
+    subdirs = [subdir for subdir in os.listdir(base_dir)
+              if os.path.isdir(os.path.join(base_dir, subdir))]
+
+    if len(subdirs) == 0:
+      raise RuntimeError("Could not find internal ROCm clang headers")
+
+    # There is usually only one subdirectory
+    return os.path.join(base_dir, subdirs[0], "include")
+
+  def run(self):
+
+    command = [self._clang] + self._common_compiler_args
+
+    if self._contains_compilation_stage:
+      command += self._compiler_args
+
+    if self._contains_linking_stage:
+      command += self._linker_args
+    
+    command += self._args
+    
+    return run_or_print(command, self._is_dry_run)
+    
+    
+
+class pure_cpu_compiler:
+  def __init__(self, config):
+    self._args = config.forwarded_compiler_arguments
+    self._contains_linking_stage = config.contains_linking_stage()
+    self._is_dry_run = config.is_dryrun
+
+    try:
+      # First, see if any value for the pure cpu compiler
+      # is specified...
+      self._compiler = config.pure_cpu_compiler
+    except:
+      # if not, fall back to clang
+      self._compiler = config.clang_path
+      
+    hipsycl_library_path = os.path.join(config.hipsycl_installation_path,"lib/")
+
+    self._linker_args = []
+    self._compiler_args = ["-fopenmp", "-std=c++14"]
+    if not config.is_bootstrap:
+      self._linker_args += [
+        "-L"+hipsycl_library_path,
+        "-lhipSYCL_cpu"
+      ]
+      self._compiler_args += [
+        "-I"+os.path.join(config.hipsycl_installation_path, "include/"),
+        "-I"+os.path.join(config.hipsycl_installation_path, "include/hipSYCL/")
+      ]
+
+  def run(self):
+    command = [self._compiler] + self._compiler_args
+    if self._contains_linking_stage:
+      command += self._linker_args
+    
+    command += self._args
+    return run_or_print(command, self._is_dry_run)
+
+def print_usage(config):
+  print("syclcc [hipSYCL] for AMD and NVIDIA devices, Copyright (C) 2018,2019 Aksel Alpay")
+  print("Usage: syclcc <options>\n")
+  print("Options are:")
+  config.print_options()
+  config.print_flags()
+  print("\nAny other options will be forwarded to the compiler.")
+  print("\nNote: Command line arguments take precedence over environment variables.")
+
+if __name__ == '__main__':
+  if sys.version_info[0] < 3:
+    print("syclcc requires python 3.")
+    sys.exit(-1)
+  
+  args = sys.argv[1:]
+
+  try:
+    config = syclcc_config(args)
+
+    if len(args) == 0:
+      print_usage(config)
+      sys.exit(-1)
+
+    for arg in args:
+      if arg == "--help":
+        print_usage(config)
+        sys.exit(0)
+
+    platform = config.target_platform
+    if platform == hipsycl_platform.CUDA or platform == hipsycl_platform.HIP:
+      compiler = clang_plugin_compiler(config)
+      sys.exit(compiler.run())
+    elif platform == hipsycl_platform.PURE_CPU:
+      compiler = pure_cpu_compiler(config)
+      sys.exit(compiler.run())
+    else:
+      raise RuntimeError("Internal error: Invalid platform '{}'".format(platform))
+  except Exception as e:
+    print("syclcc fatal error: "+str(e))
+    sys.exit(-1)

--- a/src/hipsycl_rewrite_includes/InclusionRewriter.cpp
+++ b/src/hipsycl_rewrite_includes/InclusionRewriter.cpp
@@ -448,9 +448,15 @@ bool InclusionRewriter::HandleHasInclude(
       Includers;
   Includers.push_back(std::make_pair(FileEnt, FileEnt->getDir()));
   // FIXME: Why don't we call PP.LookupFile here?
+#if LLVM_VERSION_MAJOR > 8
+  const FileEntry *File = PP.getHeaderSearchInfo().LookupFile(
+      Filename, SourceLocation(), isAngled, Lookup, CurDir, Includers, nullptr,
+      nullptr, nullptr, nullptr, nullptr, nullptr);
+#else
   const FileEntry *File = PP.getHeaderSearchInfo().LookupFile(
       Filename, SourceLocation(), isAngled, Lookup, CurDir, Includers, nullptr,
       nullptr, nullptr, nullptr, nullptr);
+#endif
 
   FileExists = File != nullptr;
   return true;

--- a/src/libhipSYCL/buffer.cpp
+++ b/src/libhipSYCL/buffer.cpp
@@ -77,7 +77,7 @@ buffer_impl::buffer_impl(size_t buffer_size,
 
 buffer_impl::buffer_impl(size_t buffer_size,
                          device_alloc_mode device_mode,
-                         host_alloc_mode host_alloc_mode)
+                         host_alloc_mode host_mode)
   : _svm{false},
     _pinned_memory{false},
     _owns_host_memory{false},
@@ -87,8 +87,8 @@ buffer_impl::buffer_impl(size_t buffer_size,
     _write_back_memory{nullptr}
 {
   if((device_mode == device_alloc_mode::svm &&
-      host_alloc_mode != host_alloc_mode::svm) ||
-     (host_alloc_mode == host_alloc_mode::svm &&
+      host_mode != host_alloc_mode::svm) ||
+     (host_mode == host_alloc_mode::svm &&
       device_mode != device_alloc_mode::svm))
     throw invalid_parameter_error{"buffer_impl: SVM allocation must be enabled on both host and device side"};
 
@@ -100,7 +100,7 @@ buffer_impl::buffer_impl(size_t buffer_size,
     throw unimplemented{"SVM allocation is currently only supported on CUDA"};
 #endif
 
-  if(host_alloc_mode != host_alloc_mode::svm)
+  if(host_mode != host_alloc_mode::svm)
     _owns_host_memory = true;
 
   if(_svm)
@@ -116,7 +116,7 @@ buffer_impl::buffer_impl(size_t buffer_size,
   {
     if(_owns_host_memory)
     {
-      if(host_alloc_mode == host_alloc_mode::allow_pinned)
+      if(host_mode == host_alloc_mode::allow_pinned)
       {
         // Try pinned memory
         if(hipHostMalloc(&_host_memory, _size, hipHostMallocDefault) == hipSuccess)


### PR DESCRIPTION
This PR adds a new compilation driver named `syclcc-clang` which is intended to replace `syclcc` in the medium term. Also included are some minor fixes for compilation with LLVM/clang 9 which is needed on ROCm.

`syclcc-clang` supports:
* compilation for CUDA with clang and the hipSYCL clang plugin
* compilation for ROCm with clang and the hipSYCL clang plugin
* compilation for CPUs with arbitrary host compiler and hipCPU

`syclcc-clang` is tested and should work for all three paths. In addition, there is preliminary support for bootstrapping hipSYCL itself with `syclcc-clang` (but it doesn't yet work directly out of the box).
It compiles the unit tests successfully with the clang plugin on all platforms (except for the caveat on ROCm below).

Important notes on ROCm support:
* In order to have the clang plugin work correctly, it must be used with the same clang version that it was compiled against. At the same time, the ROCm device library does not work correctly with LLVM < 9, because it uses very new LLVM features.
* As a consequence, in order to use the clang plugin on ROCm, the user needs to compile hipSYCL against LLVM 9 which is used by ROCm. Because ROCm does not provide packages with development files (headers) for its LLVM, unfortunately we have to require the user to install nightly LLVM builds. I do not see a way around that at the moment.
* There is some issue with the `vec<>` API test on ROCm, either related to llvm 9 (which I hadn't really tried before) or the amdgcn linker. It's the only part of the unit tests that doesn't yet compile on ROCm.

Compared to `syclcc`, `syclcc-clang` adds a couple of noteworthy new features:
* `syclcc-clang` uses a JSON configuration file in `$INSTALL_DIR/etc/hipSYCL/syclcc.json` which provides default values for syclcc options (e.g target platform). This is not only convenient for the user, it is also used to channel information from cmake to syclcc. The initial version of this file is generated by CMake based on the build configuration and contains, for example, the path to clang that the hipSYCL plugin was compiled against. This clang will then be used by syclcc, which guarantees compatibility between the compiler and our clang plugin.
* Consistent options. All options available in `syclcc-clang` behave the same way: There is a default value in the JSON config. This default value can be overwritten with an environment variable, and this environment variable can again be overwritten by a command line argument
* Executing `syclcc-clang` or `syclcc-clang --help` prints a comprehensive list of all available hipSYCL specific options, their corresponding environment variables and fields in the JSON config.
* Also new: `syclcc-clang --hipsycl-dryrun` (or using the corresponding environment variable) can be used to make `syclcc-clang` print the compiler command it wants to execute (without actually running it) which can be useful for debugging.