### PR TITLE
clang plugin: Don't use default arguments for __cudaPushCallConfiguration()

### DIFF
--- a/include/CL/sycl/backend/clang.hpp
+++ b/include/CL/sycl/backend/clang.hpp
@@ -37,8 +37,8 @@
 // called hipConfigureCall() that we can use instead.
 #ifdef __CUDA__
 extern "C" unsigned __cudaPushCallConfiguration(dim3 gridDim, dim3 blockDim,
-                                                size_t sharedMem = 0,
-                                                void *stream = 0);
+                                                size_t sharedMem,
+                                                void *stream);
 
 extern "C" unsigned __cudaPopCallConfiguration();
 


### PR DESCRIPTION
This removes the default arguments in the `__cudaPushCallConfiguration()` in `backend/clang.hpp` which fixes an error when compiling with clang 9 about redefinition of the default arguments.