### PR TITLE
clang plugin: Fix two IR pruning edge cases, refactor call graph

### DIFF
--- a/src/hipsycl_clang_plugin/HipsyclClangPlugin.cpp
+++ b/src/hipsycl_clang_plugin/HipsyclClangPlugin.cpp
@@ -45,9 +45,12 @@ static void registerFunctionPruningIRPass(const llvm::PassManagerBuilder &,
 }
 
 static llvm::RegisterStandardPasses
-  RegisterFunctionPruningIRPass(llvm::PassManagerBuilder::EP_EarlyAsPossible,
-                                registerFunctionPruningIRPass);
+  RegisterFunctionPruningIRPassOptLevel0(llvm::PassManagerBuilder::EP_EnabledOnOptLevel0,
+                                         registerFunctionPruningIRPass);
 
+static llvm::RegisterStandardPasses
+  RegisterFunctionPruningIRPassOptimizerLast(llvm::PassManagerBuilder::EP_OptimizerLast,
+                                             registerFunctionPruningIRPass);
 
 } // namespace hipsycl
 


### PR DESCRIPTION
This took a bit longer than expected. As mentioned in #66, I've encountered some issues with the new Clang plugin while trying to compile a larger code base. I've tried to determine the root causes -- with limited success. Nevertheless, I have two fixes in place that allow me to compile said code base.

First, the pruning is now performed in an LLVM `ModulePass`, instead of a `FunctionPass`. This is because the latter's `runOnFunction` callback seemingly does not always receive all functions (possibly related to
delayed instantiation of templates?) which in turn leads to those functions not being pruned, causing `ptxas` errors. First I thought this might be related to the time the function pass was being executed (`EP_EarlyAsPossible`), but interestingly running it at e.g. `EP_OptimizerLast` doesn't seem to change anything -- so I have no idea why this is happening. In any case, I think doing the pruning in a `ModulePass` makes semantically more sense. Also, as I mentioned before, I'm not even sure if the use of a `FunctionPass` was entirely legal -- at least the restrictions mentioned [here](http://llvm.org/docs/WritingAnLLVMPass.html#the-functionpass-class) seem rather harsh ("FunctionPass subclasses are not allowed to: [...] Maintain state across invocations of runOnFunction (including global data).").

The second issue is unfortunately even more obscure and the root cause is hard to pinpoint. Symptoms again include various ptxas errors, for example `ptxas fatal   : Unresolved extern function '_ZSt17__throw_bad_allocv'`. As I mentioned in #66 I first thought this was somehow related to the (potentially superfluous?) calls to `markAsHostDevice` within `FrontendASTVisitor::processFunctionDecl`. However, further investigation indicated that those calls only caused additional "entrypoints" to be emitted to the IR, and I suspect those are the real culprits. In my case this was a ton (50+) of extremely long Boost template function instantiations, that apparently are also explicitly marked as `__device__` functions (Boost does have CUDA support, after all). I honestly didn't want to dig any further into Boost, as each of those template types was at least a screen full of gibberish.

I did however find a workaround that I think is cleaner than just not calling `markAsHostDevice`: The pruning pass now only considers kernels (i.e., functions marked as `__global__`) as "entrypoints", instead of also including any function explicitly marked as `__device__`.  This change should not be a problem, as to my knowledge, Clang currently does not support device object linking (at least that's what [these](http://lists.llvm.org/pipermail/llvm-dev/2017-August/116946.html) [threads](http://clang-developers.42468.n3.nabble.com/linking-relocatable-device-object-code-with-clang-td4061009.html) seem to indicate, and I couldn't get it working myself in a brief test). Was there any other reason for including explicit device functions as entrypoints?

Lastly, while switching to a `ModulePass` I took the liberty to also cleanup and refactor the pass and to replace the custom `CallGraph` with LLVM's implementation. The main difference between the two is that the latter does not include nodes for LLVM intrinsics. For this reason, I simply don't prune any intrinsics at all -- which seems to work fine.

**Edit:** I forgot to mention: With these changes I sometimes unfortunately still get a few warnings such as `ptxas warning : Unresolved extern variable '_ZTISt13runtime_error' in whole program compilation, ignoring extern qualifier`, where `_ZTISt13runtime_error`  is a pruned function. This only occurs during debug builds, and I'm not sure how I could get rid of them.