### PR TITLE
clang plugin: Fix NVPTX debug symbols by marking functions as host/device more selectively

### DIFF
--- a/tests/device_compilation_tests.cpp
+++ b/tests/device_compilation_tests.cpp
@@ -1,0 +1,117 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2018, 2019 Aksel Alpay and contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <initializer_list>
+
+#include <CL/sycl.hpp>
+
+// What we're testing here is different forms of function calls, including
+// implicit and templated functions and constructors as well as destructors.
+// The hipSYCL Clang plugin must recognize that each of these is being called
+// by the user-provided kernel functor, and mark them as __device__ functions
+// accordingly.
+
+void foo4(int v) {
+  printf("foo4: %d\n", v);
+}
+
+struct Conversion {
+  Conversion(float value) : value(value) {
+    foo4(*this);
+  }
+
+  operator int() {
+    return static_cast<int>(value);
+  }
+
+  float value;
+};
+
+void foo3(int v) {
+  printf("foo3: %d\n", v);
+}
+
+void foo2(Conversion foo) {
+  printf("foo2: %f\n", foo.value);
+}
+
+void foo1(int v) {
+  printf("foo1: %d\n", v + 5);
+  ([=](){ foo3(v); })();
+}
+
+struct MyParent {
+  MyParent(std::initializer_list<int> init) {
+    for(auto&& e : init) {
+      parent_value += e;
+    }
+    foo1(parent_value);
+  }
+
+  virtual ~MyParent() {
+    printf("~MyParent: %d\n", parent_value);
+  };
+
+  int parent_value = 0;
+};
+
+struct MyStruct : MyParent {
+  MyStruct(int value) : MyParent::MyParent({value, 4, 5, 7}),
+    value(value) {
+  }
+
+  ~MyStruct() {
+    foo2(static_cast<float>(value));
+  }
+
+  int value;
+};
+
+template<typename T>
+int template_fn() {
+  T t(42);
+  return t.value;
+}
+
+float some_fn() {
+  return template_fn<MyStruct>();
+}
+
+int main() {
+  cl::sycl::queue queue;
+  cl::sycl::buffer<float, 1> buf(10);
+
+  queue.submit([&](cl::sycl::handler& cgh) {
+    auto acc = buf.get_access<cl::sycl::access::mode::discard_write>(cgh);
+    cgh.parallel_for<class some_kernel>(buf.get_range(), [=](cl::sycl::item<1> item) {
+        acc[item] = some_fn();
+      });
+  });
+
+  return 0;
+}
+


### PR DESCRIPTION
It looks like Clang 9 will introduce support for emitting debug symbols into NVPTX targets (in [4e9db1b](https://github.com/llvm/llvm-project/commit/4e9db1beff1cb17d7121e66c0257fa0e68fe20b6)). While that is great, it turns out that the previous approach of eagerly marking most functions as host/device and subsequently pruning them in IR appears to leave *some* residue behind that trips up `ptxas`, causing it to segfault. We previously talked about the warnings that are sometimes being generated about missing symbols - I suspect that to be related. Unfortunately this means currently it is not possible to do debug builds for any hipSYCL program using Clang 9.

I looked into how this could be remedied and together with @peterth came up with a solution:  Instead of marking everything as host/device and pruning it later, we only mark those functions that are actually being called by user kernels. This is done by first finding all user-provided kernel functions within the AST, and then only marking functions as host/device that appear within the call graph of those kernel functions.

---

The approach appears to be working well, and in fact I suspect that it could make IR pruning obsolete altogether. At least the tests as well as some of my own programs appear to compile just fine without the pruning pass. The only thing I'm not too sure about is the pruning of global variables, do you know of any specific cases of global variables that would cause issues if not pruned?