### PR TITLE
Support only clang 8 and newer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,10 +21,20 @@ FORCE)
   endif()
 endif()
 
+find_package(LLVM 9 CONFIG)
+if(NOT LLVM_FOUND)
+  find_package(LLVM 8 CONFIG)
+endif()
+
+if(NOT LLVM_FOUND)
+  message(SEND_ERROR "hipSYCL requires LLVM 8 or newer.")
+endif()
+#find_package(Clang REQUIRED)
+
 # Make sure either hcc or nvcc can be found
 find_package(CUDA)
 find_program(HCC_COMPILER NAMES hcc)
-find_program(CLANG_EXECUTABLE_PATH NAMES clang++-8 clang++-8.0 clang++-7.0 clang++-7 clang++-6.0 clang++-6 clang++ CACHE STRING)
+find_program(CLANG_EXECUTABLE_PATH NAMES clang++-9 clang++-9.0 clang++-8 clang++-8.0 clang++ CACHE STRING)
 if(CLANG_EXECUTABLE_PATH MATCHES "-NOTFOUND")
   message(SEND_ERROR "Could not find clang executable in PATH")
 endif()

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ hipSYCL depends on:
 * `cmake`
 * An appropriate compiler for the backends that you wish to compile (see above, section *Building and installing hipSYCL*)
 * HIP. On CUDA, it is not necessary to install HIP explicitly since the required headers are bundled with hipSYCL. On AMD, the system-wide HIP installation will be used instead and must be installed and working.
-* llvm/clang (with development headers and libraries). LLVM/clang 6, 7 and 8 are supported at the moment.
+* llvm/clang (with development headers and libraries). LLVM/clang 8 and 9 are supported at the moment.
 * the Boost C++ library (preprocessor, filesystem)
 
 Once these requirements are met, clone the repository with all submodules:

--- a/README.md
+++ b/README.md
@@ -64,15 +64,15 @@ hipSYCL is still in an early stage of development. It can successfully execute m
 
 ## Building and installing hipSYCL
 In order to successfully build and install hipSYCL, the following major requirements must be met:
-* **LLVM and clang >= 7** must be installed, including development files. 
+* **LLVM and clang >= 8** must be installed, including development files. 
 * *For the CUDA backend*: 
   * **CUDA >= 9.0** must be installed.
-  * For the legacy toolchain, either **clang or nvcc** must be in `$PATH`. The default (and recommended) CUDA compiler is clang due to known limitations and restrictions in nvcc's support of modern C++ features (see above). clang usually produces CUDA programs with very competitive performance compared to nvcc. Note that for CUDA 10 support, you need at least clang 8. For more information on compiling CUDA with clang, see [here](http://llvm.org/docs/CompileCudaWithLLVM.html).
-  Our internal testing is conducted with CUDA 10 and clang 8 or nvcc from CUDA 10 with gcc 7.3.
+  * For the legacy toolchain, either **clang or nvcc** must be in `$PATH`. The default (and recommended) CUDA compiler is clang due to known limitations and restrictions in nvcc's support of modern C++ features (see above). clang usually produces CUDA programs with very competitive performance compared to nvcc. For more information on compiling CUDA with clang, see [here](http://llvm.org/docs/CompileCudaWithLLVM.html).
+  Our internal testing is conducted with CUDA 10 and clang 8.
 * *For the ROCm backend*: 
   * **ROCm >= 2.0** must be installed. HIP must be installed and working. We test with the `rocm/rocm-terminal` docker image. For the legacy toolchain, **hcc** must be in `$PATH`. 
-  * In order to use the new clang-based toolchain, **hipSYCL must be compiled against the same clang version used by ROCm** (at the moment clang 9)
-* *For the CPU backend*: Any C++ compiler with **OpenMP** support should do. We test with clang 7, 8 and gcc 8.2.
+  * In order to use the new clang-based toolchain, **hipSYCL must be compiled against the same clang version used by ROCm**. This requires what AMD calls `hip-clang`.
+* *For the CPU backend*: Any C++ compiler with **OpenMP** support should do. We test with clang 8, 9 and gcc 8.2.
 
 ### Packages
 For Arch Linux users, it is recommended to simply use the `PKGBUILD` provided in `install/archlinux`. A simple `makepkg` in this directory should be enough to build an Arch Linux package.

--- a/install/docker/ROCm/Dockerfile
+++ b/install/docker/ROCm/Dockerfile
@@ -4,15 +4,20 @@ ARG hipsycl_branch=master
 ARG hipsycl_origin=https://github.com/illuhad/hipSYCL
 ENV hipsycl_branch=$hipsycl_branch
 ENV hipsycl_origin=$hipsycl_origin
-RUN sudo apt-get update
-RUN sudo apt-get install -y python3 libclang-6.0-dev clang-6.0 llvm-6.0-dev libboost-all-dev gcc
+USER root
+RUN apt-get update
+RUN apt-get install -y python3 libboost-all-dev gcc wget git
+RUN echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" >> /etc/apt/sources.list.d/llvm.list
+RUN echo "deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" >> /etc/apt/sources.list.d/llvm.list
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+RUN apt-get update
+RUN apt-get install -y libllvm8 llvm-8 llvm-8-dev llvm-8-runtime clang-8 clang-tools-8 libclang-common-8-dev libclang-8-dev libclang1-8 libomp-8-dev
 WORKDIR /tmp
 RUN git clone -b $hipsycl_branch --recurse-submodules $hipsycl_origin
 RUN mkdir /tmp/build
 WORKDIR /tmp/build
-USER root
-ENV CXX=clang++-6.0
+ENV CXX=clang++-8
 ENV PATH=/opt/rocm/bin:$PATH
 ENV HIPSYCL_GPU_ARCH=gfx900
-RUN cmake -DCMAKE_INSTALL_PREFIX=/usr -DWITH_CPU_BACKEND=ON -DWITH_ROCM_BACKEND=ON /tmp/hipSYCL
+RUN cmake -DCMAKE_C_COMPILER=clang-8 -DCMAKE_CXX_COMPILER=clang++-8 -DCMAKE_INSTALL_PREFIX=/usr -DWITH_CPU_BACKEND=ON -DWITH_ROCM_BACKEND=ON /tmp/hipSYCL
 RUN make -j$(($(nproc) -1)) install

--- a/install/singularity/hipsycl-rocm.def
+++ b/install/singularity/hipsycl-rocm.def
@@ -3,14 +3,19 @@ From: rocm/rocm-terminal
 
 %post
 apt-get update
-apt-get install -y python3 libclang-6.0-dev clang-6.0 llvm-6.0-dev libboost-all-dev gcc
-git clone --recurse-submodules https://github.com/illuhad/hipSYCL
+apt-get install -y python3 libboost-all-dev gcc wget git
+echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" >> /etc/apt/sources.list.d/llvm.list
+echo "deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" >> /etc/apt/sources.list.d/llvm.list
+wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+apt-get update
+apt-get install -y libllvm8 llvm-8 llvm-8-dev llvm-8-runtime clang-8 clang-tools-8 libclang-common-8-dev libclang-8-dev libclang1-8 libomp-8-dev
+git clone --recurse-submodules -b fix-nvptx-debug-symbols https://github.com/psalz/hipSYCL
 cd hipSYCL
 mkdir build
 cd build
-export CC=clang-6.0
-export CXX=clang++-6.0
+export CC=clang-8
+export CXX=clang++-8
 export PATH=/opt/rocm/bin:$PATH
 export HIPSYCL_GPU_ARCH=gfx900
-cmake -DCMAKE_C_COMPILER=clang-6.0 -DCMAKE_CXX_COMPILER=clang++-6.0 -DCMAKE_INSTALL_PREFIX=/usr -DWITH_CPU_BACKEND=ON -DWITH_ROCM_BACKEND=ON ..
+cmake -DCMAKE_C_COMPILER=clang-8 -DCMAKE_CXX_COMPILER=clang++-8 -DCMAKE_INSTALL_PREFIX=/usr -DWITH_CPU_BACKEND=ON -DWITH_ROCM_BACKEND=ON ..
 make -j$(($(nproc) -1)) install

--- a/src/hipsycl_clang_plugin/CMakeLists.txt
+++ b/src/hipsycl_clang_plugin/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 project(hipSYCL_clang)
 
-find_package(LLVM REQUIRED CONFIG)
-#find_package(Clang REQUIRED)
-
 
 get_filename_component(CLANG_BINARY_PREFIX ${CLANG_EXECUTABLE_PATH} DIRECTORY)
 

--- a/src/hipsycl_rewrite_includes/CMakeLists.txt
+++ b/src/hipsycl_rewrite_includes/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 project(hipsycl_rewrite_includes)
 
-find_package(LLVM REQUIRED CONFIG)
-#find_package(Clang REQUIRED)
 find_package(Boost REQUIRED COMPONENTS filesystem)
 
 get_filename_component(CLANG_BINARY_PREFIX ${CLANG_EXECUTABLE_PATH} DIRECTORY)

--- a/src/hipsycl_transform_source/CMakeLists.txt
+++ b/src/hipsycl_transform_source/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 project(hipsycl_transform_source)
 
-find_package(LLVM REQUIRED CONFIG)
-#find_package(Clang REQUIRED)
 find_package(Boost REQUIRED)
 
 


### PR DESCRIPTION
This PR bumps the officially minimum supported clang version to 8. Included is an update to the Readme as well as an update to the singularity and dockerfiles to compile with clang 8, i.e. CI will now be done with clang 8 on all platforms.
This should also fix the CI build failure of PR #76.