### PR TITLE
Bootstrap using syclcc-clang instead of syclcc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,7 @@
 cmake_minimum_required (VERSION 3.5)
 project(hipSYCL)
 
-
-set(HIPSYCL_DEVICE_COMPILER ${PROJECT_SOURCE_DIR}/bin/syclcc)
+set(HIPSYCL_DEVICE_COMPILER ${PROJECT_SOURCE_DIR}/bin/syclcc-clang)
 set(HIPSYCL_SOURCE_DIR ${PROJECT_SOURCE_DIR})
 
 if(NOT CMAKE_BUILD_TYPE)
@@ -82,6 +81,8 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+set(SYCLCC_CONFIG_FILE_PATH "${PROJECT_BINARY_DIR}/syclcc.json")
+
 add_subdirectory(src)
 
 set(DEFAULT_GPU_ARCH "" CACHE STRING "Optional: Default GPU architecture to compile for when targeting GPUs (e.g.: sm_60 or gfx900)")
@@ -98,8 +99,7 @@ set(SYCLCC_CONFIG_FILE "{
 }
 ")
 
-file(WRITE "${PROJECT_BINARY_DIR}/syclcc.json" ${SYCLCC_CONFIG_FILE})
-
+file(WRITE ${SYCLCC_CONFIG_FILE_PATH} ${SYCLCC_CONFIG_FILE})
 
 install(DIRECTORY include/CL DESTINATION include/ FILES_MATCHING PATTERN "*.hpp")
 install(DIRECTORY contrib/hipCPU/include/hipCPU DESTINATION include/hipSYCL/)
@@ -108,7 +108,7 @@ install(DIRECTORY contrib/HIP/include/ DESTINATION include/hipSYCL/)
 install(PROGRAMS bin/syclcc DESTINATION bin)
 install(PROGRAMS bin/syclcc-clang DESTINATION bin)
 
-install(FILES ${PROJECT_BINARY_DIR}/syclcc.json DESTINATION etc/hipSYCL/)
+install(FILES ${SYCLCC_CONFIG_FILE_PATH} DESTINATION etc/hipSYCL/)
 
 set(HIPSYCL_INSTALL_LOCATION ${CMAKE_INSTALL_PREFIX})
 configure_file(${PROJECT_SOURCE_DIR}/cmake/hipsycl-config.cmake.in

--- a/bin/syclcc-clang
+++ b/bin/syclcc-clang
@@ -111,7 +111,15 @@ class syclcc_config:
     config_file_path = os.path.abspath(
       os.path.join(self.hipsycl_installation_path,
                   "etc/hipSYCL/syclcc.json"))
-    self._config_file = config_file(config_file_path)
+    
+    self._config_file = None
+    # First check silently if we can open the default config file.
+    # If that fails, we try later on after argument parsing if a
+    # custom location for the config file has been supplied.
+    # (This happens when compiling hipSYCL)
+    if os.path.exists(config_file_path):
+      self._config_file = config_file(config_file_path)
+      
     self._args = args
 
     # Describes different representations of options:
@@ -140,7 +148,11 @@ class syclcc_config:
 """  The GPU architecture that should be targeted when compiling for GPUs."""),
 
       'cpu-compiler': option("--hipsycl-cpu-cxx", "HIPSYCL_CPU_CXX", "default-cpu-cxx",
-"""  The compiler that should be used when targeting only CPUs.""")
+"""  The compiler that should be used when targeting only CPUs."""),
+      
+      'config-file' : option("--hipsycl-config-file", "HIPSYCL_CONFIG_FILE", "default-config-file",
+"""  Select an alternative path for the config file containing the default hipSYCL settings.
+    It is normally not necessary for the user to change this setting.""")
     }
     self._flags = {
       'is-dryrun': option("--hipsycl-dryrun", "HIPSYCL_DRYRUN", "default-is-dryrun",
@@ -159,6 +171,16 @@ class syclcc_config:
         self._hipsycl_args.append(arg)
       else:
         self._forwarded_args.append(arg)
+        
+    if self._is_option_set_to_non_default_value("config-file"):
+      self._config_file = config_file(self._retrieve_option("config-file"))
+      
+    if self._config_file == None:
+      # If the config file is still None at this point, probably no alternative
+      # config file was supplied and the default one doesn't exist.
+      # Opening the default config file explicitly here will print a warning
+      # for the user if it doesn't exist and set the config file content to {}.
+      self._config_file = config_file(config_file_path)
 
   def _is_hipsycl_arg(self, arg):
     accepted_args = [self._options[opt].commandline for opt in self._options]
@@ -227,6 +249,18 @@ class syclcc_config:
       "environment variable {} or config file.".format(
         flag.commandline, flag.environment
     ))
+      
+  def _is_option_set_to_non_default_value(self, option_name):
+    opt = self._options[option_name]
+    
+    for arg in self._hipsycl_args:
+      if arg.startswith(opt.commandline+"="):
+        return True
+      
+    if opt.environment in os.environ:
+      return True
+    
+    return False
 
   def _retrieve_option(self, option_name):
     opt = self._options[option_name]

--- a/src/libhipSYCL/CMakeLists.txt
+++ b/src/libhipSYCL/CMakeLists.txt
@@ -19,6 +19,16 @@ set(INCLUDE_DIRS
   ${HIPSYCL_SOURCE_DIR}/include
   ${HIPSYCL_SOURCE_DIR}/contrib/hipCPU/include)
 
+set(COMMON_SYCLCC_OPTIONS --hipsycl-bootstrap --hipsycl-config-file=${SYCLCC_CONFIG_FILE_PATH})
+
+# Specify GPU architectures used when compiling libhipSYCL. 
+# They do not really matter as libhipSYCL does not
+# contain any kernel code, and are only here to make syclcc happy since it will complain if
+# there's no GPU arch specified.
+set(HIPSYCL_CUDA_DUMMY_GPU_ARCH sm_52)
+set(HIPSYCL_ROCM_DUMMY_GPU_ARCH gfx900)
+
+
 if(WITH_CUDA_BACKEND)
   add_library(hipSYCL_cuda SHARED ${HIPSYCL_SOURCES})
 
@@ -35,9 +45,9 @@ if(WITH_CUDA_BACKEND)
     set(CUDA_PLATFORM cuda)
   endif()
 
-  target_compile_options(hipSYCL_cuda PRIVATE --hipsycl-platform=${CUDA_PLATFORM} --hipsycl-bootstrap)
+  target_compile_options(hipSYCL_cuda PRIVATE --hipsycl-platform=${CUDA_PLATFORM} --hipsycl-gpu-arch=${HIPSYCL_CUDA_DUMMY_GPU_ARCH} ${COMMON_SYCLCC_OPTIONS})
   target_include_directories(hipSYCL_cuda PRIVATE ${INCLUDE_DIRS})
-  target_link_libraries(hipSYCL_cuda PRIVATE --hipsycl-platform=${CUDA_PLATFORM} --hipsycl-bootstrap)
+  target_link_libraries(hipSYCL_cuda PRIVATE --hipsycl-platform=${CUDA_PLATFORM} --hipsycl-gpu-arch=${HIPSYCL_CUDA_DUMMY_GPU_ARCH} ${COMMON_SYCLCC_OPTIONS})
   install(TARGETS hipSYCL_cuda
           EXPORT install_exports
           LIBRARY DESTINATION lib
@@ -48,12 +58,12 @@ if(WITH_ROCM_BACKEND)
   add_library(hipSYCL_rocm SHARED ${HIPSYCL_SOURCES})
   #Try to peek if ROCM set itself through its /etc/profile.d/rocm.sh
   set(ROCM_PATH $ENV{ROCM_PATH})
-  target_compile_options(hipSYCL_rocm PRIVATE --hipsycl-platform=rocm --hipsycl-bootstrap)
+  target_compile_options(hipSYCL_rocm PRIVATE --hipsycl-platform=rocm --hipsycl-gpu-arch=${HIPSYCL_ROCM_DUMMY_GPU_ARCH} ${COMMON_SYCLCC_OPTIONS})
   target_include_directories(hipSYCL_rocm PRIVATE ${INCLUDE_DIRS})
   if(ROCM_PATH)
       target_include_directories(hipSYCL_rocm PRIVATE ${ROCM_PATH}/include )
   endif()
-  target_link_libraries(hipSYCL_rocm PRIVATE --hipsycl-platform=rocm --hipsycl-bootstrap)
+  target_link_libraries(hipSYCL_rocm PRIVATE --hipsycl-platform=rocm --hipsycl-gpu-arch=${HIPSYCL_ROCM_DUMMY_GPU_ARCH} ${COMMON_SYCLCC_OPTIONS})
   install(TARGETS hipSYCL_rocm
           EXPORT install_exports
           LIBRARY DESTINATION lib
@@ -62,9 +72,9 @@ endif()
 
 if(WITH_CPU_BACKEND)
   add_library(hipSYCL_cpu SHARED ${HIPSYCL_SOURCES})
-  target_compile_options(hipSYCL_cpu PRIVATE --hipsycl-platform=cpu --hipsycl-bootstrap)
+  target_compile_options(hipSYCL_cpu PRIVATE --hipsycl-platform=cpu ${COMMON_SYCLCC_OPTIONS})
   target_include_directories(hipSYCL_cpu PRIVATE ${INCLUDE_DIRS})
-  target_link_libraries(hipSYCL_cpu PRIVATE --hipsycl-platform=cpu --hipsycl-bootstrap)
+  target_link_libraries(hipSYCL_cpu PRIVATE --hipsycl-platform=cpu ${COMMON_SYCLCC_OPTIONS})
   install(TARGETS hipSYCL_cpu
           EXPORT install_exports
           LIBRARY DESTINATION lib


### PR DESCRIPTION
This enables compilation of libhipSYCL with `syclcc-clang` instead of legacy `syclcc`. The main necessary change was to point `syclcc-clang` at the `syclcc.json` file generate by cmake.
`syclcc-clang` will then pull all information like path to clang, CUDA path etc from there.

Allowing compilation of hipSYCL with `syclcc-clang` should remove the last dependency on legacy `syclcc`.