### PR TITLE
Don't rely on OpenCL types

### DIFF
--- a/include/CL/sycl/detail/vec.hpp
+++ b/include/CL/sycl/detail/vec.hpp
@@ -46,35 +46,35 @@ template<class T>
 struct logical_vector_op_result
 {};
 
-template<> struct logical_vector_op_result<cl_char>
-{ using type = cl_char; };
+template<> struct logical_vector_op_result<detail::s_char>
+{ using type = detail::s_char; };
 
-template<> struct logical_vector_op_result<cl_uchar>
-{ using type = cl_char; };
+template<> struct logical_vector_op_result<detail::u_char>
+{ using type = detail::s_char; };
 
-template<> struct logical_vector_op_result<cl_short>
-{ using type = cl_short; };
+template<> struct logical_vector_op_result<detail::s_short>
+{ using type = detail::s_short; };
 
-template<> struct logical_vector_op_result<cl_ushort>
-{ using type = cl_short; };
+template<> struct logical_vector_op_result<detail::u_short>
+{ using type = detail::s_short; };
 
-template<> struct logical_vector_op_result<cl_int>
-{ using type = cl_int; };
+template<> struct logical_vector_op_result<detail::s_int>
+{ using type = detail::s_int; };
 
-template<> struct logical_vector_op_result<cl_uint>
-{ using type = cl_int; };
+template<> struct logical_vector_op_result<detail::u_int>
+{ using type = detail::s_int; };
 
-template<> struct logical_vector_op_result<cl_float>
-{ using type = cl_int; };
+template<> struct logical_vector_op_result<detail::sp_float>
+{ using type = detail::s_int; };
 
-template<> struct logical_vector_op_result<cl_long>
-{ using type = cl_long; };
+template<> struct logical_vector_op_result<detail::s_long>
+{ using type = detail::s_long; };
 
-template<> struct logical_vector_op_result<cl_ulong>
-{ using type = cl_long; };
+template<> struct logical_vector_op_result<detail::u_long>
+{ using type = detail::s_long; };
 
-template<> struct logical_vector_op_result<cl_double>
-{ using type = cl_long; };
+template<> struct logical_vector_op_result<detail::dp_float>
+{ using type = detail::s_long; };
 
 template<int ...>
 struct vector_index_sequence { };

--- a/include/CL/sycl/device.hpp
+++ b/include/CL/sycl/device.hpp
@@ -179,7 +179,7 @@ HIPSYCL_SPECIALIZE_GET_INFO(device, max_compute_units)
 {
   hipDeviceProp_t props;
   detail::check_error(hipGetDeviceProperties(&props, _device_id));
-  return static_cast<cl_uint>(props.multiProcessorCount);
+  return static_cast<detail::u_int>(props.multiProcessorCount);
 }
 
 HIPSYCL_SPECIALIZE_GET_INFO(device, max_work_item_dimensions)
@@ -238,7 +238,7 @@ HIPSYCL_SPECIALIZE_GET_INFO(device, max_clock_frequency)
 {
   hipDeviceProp_t props;
   detail::check_error(hipGetDeviceProperties(&props, _device_id));
-  return static_cast<cl_uint>(props.clockRate / 1000);
+  return static_cast<detail::u_int>(props.clockRate / 1000);
 }
 
 HIPSYCL_SPECIALIZE_GET_INFO(device, address_bits)
@@ -249,7 +249,7 @@ HIPSYCL_SPECIALIZE_GET_INFO(device, max_mem_alloc_size)
   // return global memory size for now
   hipDeviceProp_t props;
   detail::check_error(hipGetDeviceProperties(&props, _device_id));
-  return static_cast<cl_ulong>(props.totalGlobalMem);
+  return static_cast<detail::u_long>(props.totalGlobalMem);
 }
 
 HIPSYCL_SPECIALIZE_GET_INFO(device, image_support)
@@ -293,7 +293,7 @@ HIPSYCL_SPECIALIZE_GET_INFO(device, image_max_array_size)
 
 /// \todo Find out actual value
 HIPSYCL_SPECIALIZE_GET_INFO(device, max_samplers)
-{ return std::numeric_limits<cl_uint>::max(); }
+{ return std::numeric_limits<detail::u_int>::max(); }
 
 HIPSYCL_SPECIALIZE_GET_INFO(device, max_parameter_size)
 { return std::numeric_limits<size_t>::max(); }
@@ -361,25 +361,25 @@ HIPSYCL_SPECIALIZE_GET_INFO(device, global_mem_cache_size)
 {
   hipDeviceProp_t props;
   detail::check_error(hipGetDeviceProperties(&props, _device_id));
-  return static_cast<cl_ulong>(props.l2CacheSize);
+  return static_cast<detail::u_long>(props.l2CacheSize);
 }
 
 HIPSYCL_SPECIALIZE_GET_INFO(device, global_mem_size)
 {
   hipDeviceProp_t props;
   detail::check_error(hipGetDeviceProperties(&props, _device_id));
-  return static_cast<cl_ulong>(props.totalGlobalMem);
+  return static_cast<detail::u_long>(props.totalGlobalMem);
 }
 
 HIPSYCL_SPECIALIZE_GET_INFO(device, max_constant_buffer_size)
 {
   hipDeviceProp_t props;
   detail::check_error(hipGetDeviceProperties(&props, _device_id));
-  return static_cast<cl_ulong>(props.totalConstMem);
+  return static_cast<detail::u_long>(props.totalConstMem);
 }
 
 HIPSYCL_SPECIALIZE_GET_INFO(device, max_constant_args)
-{ return std::numeric_limits<cl_uint>::max(); }
+{ return std::numeric_limits<detail::u_int>::max(); }
 
 HIPSYCL_SPECIALIZE_GET_INFO(device, local_mem_type)
 { return info::local_mem_type::local; }
@@ -388,7 +388,7 @@ HIPSYCL_SPECIALIZE_GET_INFO(device, local_mem_size)
 {
   hipDeviceProp_t props;
   detail::check_error(hipGetDeviceProperties(&props, _device_id));
-  return static_cast<cl_ulong>(props.sharedMemPerBlock);
+  return static_cast<detail::u_long>(props.sharedMemPerBlock);
 }
 
 /// \todo actually check support

--- a/include/CL/sycl/info/context.hpp
+++ b/include/CL/sycl/info/context.hpp
@@ -48,7 +48,7 @@ enum class context : int {
 
 HIPSYCL_PARAM_TRAIT_RETURN_VALUE(context,
                                  context::reference_count,
-                                 cl_uint);
+                                 detail::u_int);
 
 HIPSYCL_PARAM_TRAIT_RETURN_VALUE(context,
                                  context::platform,

--- a/include/CL/sycl/info/device.hpp
+++ b/include/CL/sycl/info/device.hpp
@@ -170,35 +170,35 @@ enum class execution_capability : unsigned int {
 };
 
 HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::device_type, device_type);
-HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::vendor_id, cl_uint);
-HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::max_compute_units, cl_uint);
-HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::max_work_item_dimensions, cl_uint);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::vendor_id, detail::u_int);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::max_compute_units, detail::u_int);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::max_work_item_dimensions, detail::u_int);
 HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::max_work_item_sizes, id<3>);
 HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::max_work_group_size, size_t);
 
-HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::preferred_vector_width_char, cl_uint);
-HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::preferred_vector_width_double, cl_uint);
-HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::preferred_vector_width_float, cl_uint);
-HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::preferred_vector_width_half, cl_uint);
-HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::preferred_vector_width_int, cl_uint);
-HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::preferred_vector_width_long, cl_uint);
-HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::preferred_vector_width_short, cl_uint);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::preferred_vector_width_char, detail::u_int);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::preferred_vector_width_double, detail::u_int);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::preferred_vector_width_float, detail::u_int);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::preferred_vector_width_half, detail::u_int);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::preferred_vector_width_int, detail::u_int);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::preferred_vector_width_long, detail::u_int);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::preferred_vector_width_short, detail::u_int);
 
-HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::native_vector_width_char, cl_uint);
-HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::native_vector_width_double, cl_uint);
-HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::native_vector_width_float, cl_uint);
-HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::native_vector_width_half, cl_uint);
-HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::native_vector_width_int, cl_uint);
-HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::native_vector_width_long, cl_uint);
-HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::native_vector_width_short, cl_uint);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::native_vector_width_char, detail::u_int);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::native_vector_width_double, detail::u_int);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::native_vector_width_float, detail::u_int);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::native_vector_width_half, detail::u_int);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::native_vector_width_int, detail::u_int);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::native_vector_width_long, detail::u_int);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::native_vector_width_short, detail::u_int);
 
-HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::max_clock_frequency, cl_uint);
-HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::address_bits, cl_uint);
-HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::max_mem_alloc_size, cl_ulong);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::max_clock_frequency, detail::u_int);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::address_bits, detail::u_int);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::max_mem_alloc_size, detail::u_long);
 HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::image_support, bool);
 
-HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::max_read_image_args, cl_uint);
-HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::max_write_image_args, cl_uint);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::max_read_image_args, detail::u_int);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::max_write_image_args, detail::u_int);
 
 HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::image2d_max_width, size_t);
 HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::image2d_max_height, size_t);
@@ -208,24 +208,24 @@ HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::image3d_max_depth, size_t);
 HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::image_max_buffer_size, size_t);
 HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::image_max_array_size, size_t);
 
-HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::max_samplers, cl_uint);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::max_samplers, detail::u_int);
 HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::max_parameter_size, size_t);
-HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::mem_base_addr_align, cl_uint);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::mem_base_addr_align, detail::u_int);
 
 HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::half_fp_config, vector_class<fp_config>);
 HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::single_fp_config, vector_class<fp_config>);
 HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::double_fp_config, vector_class<fp_config>);
 
 HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::global_mem_cache_type, global_mem_cache_type);
-HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::global_mem_cache_line_size, cl_uint);
-HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::global_mem_cache_size, cl_ulong);
-HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::global_mem_size, cl_ulong);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::global_mem_cache_line_size, detail::u_int);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::global_mem_cache_size, detail::u_long);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::global_mem_size, detail::u_long);
 
-HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::max_constant_buffer_size, cl_ulong);
-HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::max_constant_args, cl_uint);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::max_constant_buffer_size, detail::u_long);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::max_constant_args, detail::u_int);
 
 HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::local_mem_type, local_mem_type);
-HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::local_mem_size, cl_ulong);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::local_mem_size, detail::u_long);
 
 HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::error_correction_support, bool);
 HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::host_unified_memory, bool);
@@ -250,12 +250,12 @@ HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::extensions, vector_class<string
 HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::printf_buffer_size, size_t);
 HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::preferred_interop_user_sync, bool);
 HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::parent_device, sycl::device);
-HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::partition_max_sub_devices, cl_uint);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::partition_max_sub_devices, detail::u_int);
 HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::partition_properties, vector_class<partition_property>);
 HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::partition_affinity_domains, vector_class<partition_affinity_domain>);
 HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::partition_type_property, partition_property);
 HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::partition_type_affinity_domain, partition_affinity_domain);
-HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::reference_count, cl_uint);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::reference_count, detail::u_int);
 
 } // namespace info
 } // namespace sycl

--- a/include/CL/sycl/info/event.hpp
+++ b/include/CL/sycl/info/event.hpp
@@ -58,7 +58,7 @@ enum class event_profiling : int
 
 
 HIPSYCL_PARAM_TRAIT_RETURN_VALUE(event, event::command_execution_status, event_command_status);
-HIPSYCL_PARAM_TRAIT_RETURN_VALUE(event, event::reference_count, cl_uint);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(event, event::reference_count, detail::u_int);
 
 }
 }

--- a/include/CL/sycl/info/queue.hpp
+++ b/include/CL/sycl/info/queue.hpp
@@ -49,7 +49,7 @@ enum class queue : int
 
 HIPSYCL_PARAM_TRAIT_RETURN_VALUE(queue, queue::context, sycl::context);
 HIPSYCL_PARAM_TRAIT_RETURN_VALUE(queue, queue::device, sycl::device);
-HIPSYCL_PARAM_TRAIT_RETURN_VALUE(queue, queue::reference_count, cl_uint);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(queue, queue::reference_count, detail::u_int);
 
 }
 }

--- a/include/CL/sycl/types.hpp
+++ b/include/CL/sycl/types.hpp
@@ -85,40 +85,45 @@ using exception_list = vector_class<exception_ptr>;
 using async_handler = function_class<void(cl::sycl::exception_list)>;
 
 // \todo Better use uint32_t etc
-using cl_uchar = unsigned char;
-using cl_ushort = unsigned short;
-using cl_uint = unsigned;
-using cl_ulong = unsigned long long;
+namespace detail {
+// Define types in analogy to OpenCL cl_* types
+using u_char = unsigned char;
+using u_short = unsigned short;
+using u_int = unsigned;
+using u_long = unsigned long long;
 
-using cl_char = char;
-using cl_short = short;
-using cl_int = int;
-using cl_long = long long;
+using s_char = char;
+using s_short = short;
+using s_int = int;
+using s_long = long long;
 
-using cl_float = float;
-using cl_double = double;
 // ToDo: Proper half type
-using cl_half = cl_ushort;
+using hp_float = u_short;
+using sp_float = float;
+using dp_float = double;
+} //detail
 
-}
-}
+} // sycl
+} // cl
 
 // Only pull typedefs into global namespace if the OpenCL headers
 // defining them haven't yet been pulled in
 #ifndef CL_TARGET_OPENCL_VERSION
-using cl::sycl::cl_uchar;
-using cl::sycl::cl_ushort;
-using cl::sycl::cl_uint;
-using cl::sycl::cl_ulong;
+#ifdef HIPSYCL_DEFINE_OPENCL_TYPES
+using cl_uchar  = cl::sycl::detail::u_char;
+using cl_ushort = cl::sycl::detail::u_short;
+using cl_uint   = cl::sycl::detail::u_int;
+using cl_ulong  = cl::sycl::detail::u_long;
 
-using cl::sycl::cl_char;
-using cl::sycl::cl_short;
-using cl::sycl::cl_int;
-using cl::sycl::cl_long;
+using cl_char  = cl::sycl::detail::s_char;
+using cl_short = cl::sycl::detail::s_short;
+using cl_int   = cl::sycl::detail::s_int;
+using cl_long  = cl::sycl::detail::s_long;
 
-using cl::sycl::cl_float;
-using cl::sycl::cl_double;
-using cl::sycl::cl_half;
+using cl_float  = cl::sycl::detail::sp_float;
+using cl_double = cl::sycl::detail::dp_float;
+using cl_half   = cl::sycl::detail::hp_float;
+#endif
 #endif
 
 #endif

--- a/include/CL/sycl/vec.hpp
+++ b/include/CL/sycl/vec.hpp
@@ -1506,18 +1506,21 @@ HIPSYCL_DEFINE_VECTOR_ALIAS(int, int);
 HIPSYCL_DEFINE_VECTOR_ALIAS(long, long);
 HIPSYCL_DEFINE_VECTOR_ALIAS(float, float);
 HIPSYCL_DEFINE_VECTOR_ALIAS(double, double);
-// ToDo: half
-HIPSYCL_DEFINE_VECTOR_ALIAS(cl_char, cl_char);
-HIPSYCL_DEFINE_VECTOR_ALIAS(cl_uchar, cl_uchar);
-HIPSYCL_DEFINE_VECTOR_ALIAS(cl_short, cl_short);
-HIPSYCL_DEFINE_VECTOR_ALIAS(cl_ushort, cl_ushort);
-HIPSYCL_DEFINE_VECTOR_ALIAS(cl_int, cl_int);
-HIPSYCL_DEFINE_VECTOR_ALIAS(cl_uint, cl_uint);
-HIPSYCL_DEFINE_VECTOR_ALIAS(cl_long, cl_long);
-HIPSYCL_DEFINE_VECTOR_ALIAS(cl_ulong, cl_ulong);
-HIPSYCL_DEFINE_VECTOR_ALIAS(cl_float, cl_float);
-HIPSYCL_DEFINE_VECTOR_ALIAS(cl_double, cl_double);
-// ToDo: half
+HIPSYCL_DEFINE_VECTOR_ALIAS(detail::hp_float, half);
+
+HIPSYCL_DEFINE_VECTOR_ALIAS(detail::s_char, cl_char);
+HIPSYCL_DEFINE_VECTOR_ALIAS(detail::u_char, cl_uchar);
+HIPSYCL_DEFINE_VECTOR_ALIAS(detail::s_short, cl_short);
+HIPSYCL_DEFINE_VECTOR_ALIAS(detail::u_short, cl_ushort);
+HIPSYCL_DEFINE_VECTOR_ALIAS(detail::s_int, cl_int);
+HIPSYCL_DEFINE_VECTOR_ALIAS(detail::u_int, cl_uint);
+HIPSYCL_DEFINE_VECTOR_ALIAS(detail::s_long, cl_long);
+HIPSYCL_DEFINE_VECTOR_ALIAS(detail::u_long, cl_ulong);
+HIPSYCL_DEFINE_VECTOR_ALIAS(detail::sp_float, cl_float);
+HIPSYCL_DEFINE_VECTOR_ALIAS(detail::dp_float, cl_double);
+HIPSYCL_DEFINE_VECTOR_ALIAS(detail::hp_float, cl_half);
+
+
 HIPSYCL_DEFINE_VECTOR_ALIAS(signed char, schar);
 HIPSYCL_DEFINE_VECTOR_ALIAS(unsigned char, uchar);
 HIPSYCL_DEFINE_VECTOR_ALIAS(unsigned short, ushort);
@@ -1525,6 +1528,7 @@ HIPSYCL_DEFINE_VECTOR_ALIAS(unsigned int, uint);
 HIPSYCL_DEFINE_VECTOR_ALIAS(unsigned long, ulong);
 HIPSYCL_DEFINE_VECTOR_ALIAS(long long, longlong);
 HIPSYCL_DEFINE_VECTOR_ALIAS(unsigned long long, ulonglong);
+
 
 
 namespace detail {


### PR DESCRIPTION
Currently, hipSYCL redefines OpenCL types like `cl_int` in `types.hpp`, unless OpenCL headers where already included before, in the hope of improving compatibility with SYCL applications that assume OpenCL.
In practice, this can lead to redefinition problems if the OpenCL headers are included after the SYCL headers.

This PR removes the dependency on OpenCL types for internal types used by hipSYCL, and replaces these types by custom typedefs in the form of e.g. `sycl::detail::u_int` for a 32 bit unsigned int.
This change is likely also in line with the future direction of SYCL, since it is expected that SYCL will become more independent of OpenCL.

For compatibility, the OpenCL type definitions can be reenabled with the `HIPSYCL_DEFINE_OPENCL_TYPES` macro.