### PR TITLE
Add initial implementation of `program` and `kernel`

### DIFF
--- a/include/CL/sycl.hpp
+++ b/include/CL/sycl.hpp
@@ -53,6 +53,8 @@
 #include "sycl/builtin.hpp"
 #include "sycl/math.hpp"
 #include "sycl/atomic.hpp"
+#include "sycl/program.hpp"
+#include "sycl/kernel.hpp"
 
 #endif
 

--- a/include/CL/sycl/info/kernel.hpp
+++ b/include/CL/sycl/info/kernel.hpp
@@ -1,0 +1,83 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2019 Aksel Alpay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef HIPSYCL_INFO_KERNEL_HPP
+#define HIPSYCL_INFO_KERNEL_HPP
+
+#include "../types.hpp"
+#include "param_traits.hpp"
+#include "../range.hpp"
+
+namespace cl {
+namespace sycl {
+
+class context;
+class program;
+
+namespace info {
+
+enum class kernel : int {
+  function_name,
+  num_args,
+  context,
+  program,
+  reference_count,
+  attributes
+};
+
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(kernel, kernel::function_name, string_class);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(kernel, kernel::num_args, detail::u_int);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(kernel, kernel::context, sycl::context);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(kernel, kernel::program, sycl::program);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(kernel, kernel::reference_count, detail::u_int);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(kernel, kernel::attributes, string_class);
+
+enum class kernel_work_group : int
+{
+  global_work_size,
+  work_group_size,
+  compile_work_group_size,
+  preferred_work_group_size_multiple,
+  private_mem_size
+};
+
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(kernel_work_group, 
+                                kernel_work_group::global_work_size, sycl::range<3>);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(kernel_work_group, 
+                                kernel_work_group::work_group_size, size_t);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(kernel_work_group, 
+                                kernel_work_group::compile_work_group_size, sycl::range<3>);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(kernel_work_group, 
+                                kernel_work_group::preferred_work_group_size_multiple, size_t);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(kernel_work_group, 
+                                kernel_work_group::private_mem_size, detail::u_long);
+
+} // info
+} // sycl
+} // cl
+
+#endif

--- a/include/CL/sycl/info/program.hpp
+++ b/include/CL/sycl/info/program.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
  *
- * Copyright (c) 2018,2019 Aksel Alpay
+ * Copyright (c) 2019 Aksel Alpay
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,21 +25,33 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef HIPSYCL_INFO_HPP
-#define HIPSYCL_INFO_HPP
+#ifndef HIPSYCL_INFO_PROGRAM_HPP
+#define HIPSYCL_INFO_PROGRAM_HPP
 
+#include "../types.hpp"
 #include "param_traits.hpp"
-#include "context.hpp"
-#include "device.hpp"
-#include "event.hpp"
-#include "platform.hpp"
-#include "queue.hpp"
-#include "kernel.hpp"
-#include "program.hpp"
 
-#define HIPSYCL_SPECIALIZE_GET_INFO(class_name, specialization)\
-  template<> \
-  inline typename info::param_traits<info::class_name,info::class_name::specialization>::return_type \
-  sycl::class_name::get_info<info::class_name::specialization>() const
+namespace cl {
+namespace sycl {
+
+class device;
+class context;
+
+namespace info {
+
+enum class program : int
+{
+  reference_count,
+  context,
+  devices
+};
+
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(program, program::reference_count, detail::u_int);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(program, program::context, sycl::context);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(program, program::devices, vector_class<sycl::device>);
+
+} // info
+} // sycl
+} // cl
 
 #endif

--- a/include/CL/sycl/kernel.hpp
+++ b/include/CL/sycl/kernel.hpp
@@ -1,0 +1,148 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2019 Aksel Alpay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef HIPSYCL_KERNEL_HPP
+#define HIPSYCL_KERNEL_HPP
+
+#include "context.hpp"
+#include "program.hpp"
+#include "device.hpp"
+#include "info/info.hpp"
+
+namespace cl {
+namespace sycl {
+
+// This class is mostly a dummy implementation
+class kernel 
+{
+private:
+  friend class program;
+  // The default object is not valid because there is no
+  // program or cl_kernel associated with it
+  kernel();
+
+  context _ctx;
+public:
+  template<class Kernel_type>  
+  kernel(Kernel_type clKernel, const context& syclContext)
+  : _ctx{syclContext}
+  {}
+  
+  /* -- common interface members -- */
+  
+  //cl_kernel get() const;
+
+  bool is_host() const
+  {
+    return _ctx.is_host();
+  }
+
+  context get_context() const
+  {
+    return _ctx;
+  }
+
+  program get_program() const;
+  
+  template <info::kernel param>
+  typename info::param_traits<info::kernel, param>::return_type 
+  get_info() const;
+
+  template <info::kernel_work_group param>
+  typename info::param_traits<info::kernel_work_group, param>::return_type
+  get_work_group_info(const device &dev) const;
+};
+
+HIPSYCL_SPECIALIZE_GET_INFO(kernel, function_name)
+{ return "<implicitly mangled kernel name>"; }
+
+HIPSYCL_SPECIALIZE_GET_INFO(kernel, num_args)
+{ return 0; }
+
+HIPSYCL_SPECIALIZE_GET_INFO(kernel, context)
+{ return get_context(); }
+
+HIPSYCL_SPECIALIZE_GET_INFO(kernel, program)
+{ return get_program(); }
+
+HIPSYCL_SPECIALIZE_GET_INFO(kernel, reference_count)
+{ return 1; }
+
+HIPSYCL_SPECIALIZE_GET_INFO(kernel, attributes)
+{ return ""; }
+
+#define HIPSYCL_SPECIALIZE_KERNEL_GET_WORK_GROUP_INFO(specialization)\
+  template<> \
+  inline typename info::param_traits< \
+        info::kernel_work_group, \
+        info::kernel_work_group::specialization>::return_type \
+  kernel::get_work_group_info<info::kernel_work_group::specialization>(const device& dev) const
+
+HIPSYCL_SPECIALIZE_KERNEL_GET_WORK_GROUP_INFO(global_work_size)
+{
+  // ToDO
+  return range<3>{0,0,0};
+}
+
+HIPSYCL_SPECIALIZE_KERNEL_GET_WORK_GROUP_INFO(work_group_size)
+{
+  return dev.get_info<info::device::max_work_group_size>();
+}
+
+HIPSYCL_SPECIALIZE_KERNEL_GET_WORK_GROUP_INFO(compile_work_group_size)
+{
+  return range<3>{0,0,0};
+}
+
+HIPSYCL_SPECIALIZE_KERNEL_GET_WORK_GROUP_INFO(preferred_work_group_size_multiple)
+{
+  // ToDo
+  return 128;
+}
+
+HIPSYCL_SPECIALIZE_KERNEL_GET_WORK_GROUP_INFO(private_mem_size)
+{
+  // ToDo
+  return 0;
+}
+
+
+template <typename kernelT>
+kernel program::get_kernel() const
+{
+  return kernel{"dummy-parameter", _ctx};
+}
+
+kernel program::get_kernel(string_class kernelName) const
+{
+  return kernel{"dummy-parameter", _ctx};
+}
+
+}
+}
+
+#endif

--- a/include/CL/sycl/program.hpp
+++ b/include/CL/sycl/program.hpp
@@ -1,0 +1,156 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2019 Aksel Alpay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef HIPSYCL_PROGRAM_HPP
+#define HIPSYCL_PROGRAM_HPP
+
+#include "types.hpp"
+#include "context.hpp"
+#include "exception.hpp"
+#include "info/info.hpp"
+
+namespace cl {
+namespace sycl {
+
+enum class program_state 
+{
+  none,
+  compiled,
+  linked
+};
+
+class kernel;
+
+// Dummy implementation of SYCL program class
+class program 
+{
+  context _ctx;
+public:
+  program() = delete;
+  
+  explicit program(const context &context)
+  : _ctx{context}
+  {}
+
+  program(const context &context, vector_class<device> deviceList)
+  : _ctx{context}
+  {}
+  program(vector_class<program> programList, string_class linkOptions = ""){}
+
+  template<class Cl_program>
+  program(const context &context, Cl_program clProgram)
+  : _ctx{context}
+  {}
+  
+  /* -- common interface members -- */
+  //cl_program get() const;
+
+  bool is_host() const
+  {
+    return _ctx.is_host();
+  }
+  
+  template <typename kernelT>
+  void compile_with_kernel_type(string_class compileOptions = "")
+  {}
+
+  void compile_with_source(string_class kernelSource, string_class compileOptions = "")
+  {}
+
+  template <typename kernelT> void build_with_kernel_type(string_class buildOptions = "")
+  {}
+
+  void build_with_source(string_class kernelSource, string_class buildOptions = "")
+  {
+    // On CUDA, we may be able to use NVRTC library here for runtime compilation?
+    throw unimplemented{"program::build_with_source() is unimplemented."};
+  }
+
+  void link(string_class linkOptions = "")
+  {}
+
+  template <typename kernelT> 
+  bool has_kernel() const
+  { return true; }
+
+  bool has_kernel(string_class kernelName) const
+  { return true; }
+
+  // get_kernel() is implemented in kernel.hpp.
+  template <typename kernelT>
+  kernel get_kernel() const;
+  kernel get_kernel(string_class kernelName) const;
+
+  template <info::program param> typename info::param_traits<info::program, param>::return_type
+  get_info() const;
+  
+  vector_class<vector_class<char>> get_binaries() const
+  {
+    return vector_class<vector_class<char>>{};
+  }
+  
+  context get_context() const
+  {
+    return _ctx;
+  }
+
+  vector_class<device> get_devices() const;
+
+  string_class get_compile_options() const
+  { return ""; }
+
+  string_class get_link_options() const
+  { return ""; }
+
+  string_class get_build_options() const
+  { return ""; }
+
+  program_state get_state() const
+  {
+    return program_state::linked;
+  }
+};
+
+HIPSYCL_SPECIALIZE_GET_INFO(program, reference_count)
+{
+  return 1;
+}
+
+HIPSYCL_SPECIALIZE_GET_INFO(program, context)
+{
+  return get_context();
+}
+
+HIPSYCL_SPECIALIZE_GET_INFO(program, devices)
+{
+  return get_context().get_devices();
+}
+
+}
+}
+
+#endif


### PR DESCRIPTION
This adds initial implementations of the `program` and `kernel` classes. For now, they are mostly dummy implementations that aren't really functional, but it does allow us to proceed a bit further when compiling SYCL CTS.