### PR TITLE
Fix multiple definition errors of program::get_kernel()

### DIFF
--- a/include/CL/sycl/kernel.hpp
+++ b/include/CL/sycl/kernel.hpp
@@ -132,12 +132,12 @@ HIPSYCL_SPECIALIZE_KERNEL_GET_WORK_GROUP_INFO(private_mem_size)
 
 
 template <typename kernelT>
-kernel program::get_kernel() const
+inline kernel program::get_kernel() const
 {
   return kernel{"dummy-parameter", _ctx};
 }
 
-kernel program::get_kernel(string_class kernelName) const
+inline kernel program::get_kernel(string_class kernelName) const
 {
   return kernel{"dummy-parameter", _ctx};
 }


### PR DESCRIPTION
This fixes the errors reported in issue #85 by marking `program::get_kernel()` as inline.