### PR TITLE
Add local_accessor alias for local accessors

### DIFF
--- a/include/CL/sycl/accessor.hpp
+++ b/include/CL/sycl/accessor.hpp
@@ -720,6 +720,10 @@ private:
   const range<dimensions> _num_elements;
 };
 
+template <typename dataT, int dimensions = 1>
+using local_accessor = accessor<dataT, dimensions, access::mode::read_write,
+  access::target::local>;
+
 namespace detail {
 namespace accessor {
 


### PR DESCRIPTION
This adds the alias for local accessors as described in [this](https://github.com/KhronosGroup/SYCL-Docs/pull/17) PR for the SYCL spec.