### PR TITLE
Improve performance on CPU by changing execution and memory model

### DIFF
--- a/bin/syclcc-clang
+++ b/bin/syclcc-clang
@@ -487,10 +487,12 @@ class pure_cpu_compiler:
 
   def run(self):
     command = [self._compiler] + self._compiler_args
+
+    command += self._args
+    # For GCC, linked libraries must follow the object files
     if self._contains_linking_stage:
       command += self._linker_args
     
-    command += self._args
     return run_or_print(command, self._is_dry_run)
 
 def print_usage(config):

--- a/doc/macros.md
+++ b/doc/macros.md
@@ -10,6 +10,7 @@ Most of these are managed by `detail/backend/backend.hpp`.
 * `__HIPSYCL_DEVICE__` - defined if generating code for GPU
 * `SYCL_DEVICE_ONLY` - defined if generating code for GPU
 * `HIPSYCL_CLANG` - defined by `syclcc-clang` when compiling with the clang plugin
+* `HIPSYCL_SVM_SUPPORTED` - defined when the backend supports unified memory
 
 ## Mainly for hipSYCL developers
 * `__HIPSYCL_TRANSFORM__` defined by legacy `syclcc` during the source-to-source transformation step
@@ -19,3 +20,4 @@ Most of these are managed by `detail/backend/backend.hpp`.
 
 # Configuration macros
 * `HIPSYCL_EXT_FP_ATOMICS` - define before including `sycl.hpp` to enable the hipSYCL extension to allow atomic operations on floating point types. Since this is not in the spec, this may break portability. Additionally, not all hipSYCL backends may support the same set of FP atomics. It is the user's responsibility to ensure that the code remains portable and to implement fallbacks for platforms that don't support this.
+* `HIPSYCL_CPU_EMULATE_SEPARATE_MEMORY` - define during compilation of hipSYCL and SYCL programs to force the CPU backend to consider host and device memory as separate memory regions that require data transfers in between. This can be useful for debugging since it recreates what happens when targeting GPUs.

--- a/include/CL/sycl/backend/backend.hpp
+++ b/include/CL/sycl/backend/backend.hpp
@@ -90,6 +90,11 @@
  #define __hipsycl_launch_kernel hipLaunchKernelGGL
 #endif
 
+
+#if defined(HIPSYCL_PLATFORM_CUDA) || defined(HIPSYCL_PLATFORM_CPU)
+  #define HIPSYCL_SVM_SUPPORTED
+#endif
+
 #if defined(SYCL_DEVICE_ONLY)
  // If HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO is defined,
  // information about the iteration space like thread id, block id

--- a/include/CL/sycl/backend/backend.hpp
+++ b/include/CL/sycl/backend/backend.hpp
@@ -69,6 +69,7 @@
 
 
 #ifdef __HIP_DEVICE_COMPILE__
+ // These macros are set if we are currently compiling for GPU.
  #define __HIPSYCL_DEVICE__
  #define SYCL_DEVICE_ONLY
 #endif
@@ -87,6 +88,39 @@
 #else
  #define __sycl_kernel __global__
  #define __hipsycl_launch_kernel hipLaunchKernelGGL
+#endif
+
+#if defined(SYCL_DEVICE_ONLY)
+ // If HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO is defined,
+ // information about the iteration space like thread id, block id
+ // block size, grid size will be queried on demand instead of being
+ // stored inside the item, nd_item, etc SYCL classes.
+ // Depending on the quality of compiler optimizations, this may or may
+ // not help to reduce register pressure.
+ // TODO: We need benchmarks to check the impact! Code could be simplified
+ // if it turns out that we don't need it and compiler optimizations are
+ // reliably good enough.
+ //
+ // HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO is only available on GPU.
+ #define HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
+#endif
+
+#ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
+ #if !defined (__HIPSYCL_DEVICE_CALLABLE__)
+  // On demand iteration space info is in particular unavailable on CPU
+  #error Ondemand iteration space querying cannot be activated, __device__ functions are unavailable!
+ #endif
+#endif
+
+#ifdef HIPSYCL_PLATFORM_CPU
+ // This enables kernel invocation via the OpenMP host kernel
+ // execution model (instead of plain HIP/hipCPU).
+ // Ultimately, for runtime device selection between host/gpu
+ // this should always be active. However, currently it is not
+ // not yet possible to use hipCPU at the same time as regular GPU HIP,
+ // so we can only enable compiling for host when the platform is
+ // pure CPU.
+ #define HIPSYCL_ENABLE_HOST_KERNEL_INVOCATION
 #endif
 
 namespace cl {

--- a/include/CL/sycl/detail/buffer.hpp
+++ b/include/CL/sycl/detail/buffer.hpp
@@ -127,7 +127,8 @@ public:
               host_alloc_mode host_alloc_mode = host_alloc_mode::regular);
 
   buffer_impl(size_t buffer_size,
-              void* host_ptr);
+              void* host_ptr,
+              bool is_svm_ptr = false);
 
   ~buffer_impl();
 

--- a/include/CL/sycl/detail/data_layout.hpp
+++ b/include/CL/sycl/detail/data_layout.hpp
@@ -65,10 +65,10 @@ struct linear_id
 template<>
 struct linear_id<1>
 {
-  static HIPSYCL_UNIVERSAL_TARGET size_t get(const id<1>& idx)
+  static HIPSYCL_UNIVERSAL_TARGET size_t get(const sycl::id<1>& idx)
   { return idx[0]; }
 
-  static HIPSYCL_UNIVERSAL_TARGET size_t get(const id<1>& idx,
+  static HIPSYCL_UNIVERSAL_TARGET size_t get(const sycl::id<1>& idx,
                                             const sycl::range<1>& r)
   {
     return get(idx);
@@ -78,7 +78,7 @@ struct linear_id<1>
 template<>
 struct linear_id<2>
 {
-  static HIPSYCL_UNIVERSAL_TARGET size_t get(const id<2>& idx,
+  static HIPSYCL_UNIVERSAL_TARGET size_t get(const sycl::id<2>& idx,
                                         const sycl::range<2>& r)
   {
     return get_linear_id(idx.get(0), idx.get(1), r.get(1));
@@ -88,7 +88,7 @@ struct linear_id<2>
 template<>
 struct linear_id<3>
 {
-  static HIPSYCL_UNIVERSAL_TARGET size_t get(const id<3>& idx,
+  static HIPSYCL_UNIVERSAL_TARGET size_t get(const sycl::id<3>& idx,
                                         const sycl::range<3>& r)
   {
     return get_linear_id(idx.get(0), idx.get(1), idx.get(2), r.get(1), r.get(2));
@@ -162,7 +162,7 @@ private:
           x < end;
           ++x)
       {
-        f(linear_data_range{linear_id<2>::get(id<2>{x,_offset.get(1)},_shape),
+        f(linear_data_range{linear_id<2>::get(sycl::id<2>{x,_offset.get(1)},_shape),
                             _access_range.get(1)});
       }
     }
@@ -196,7 +196,7 @@ private:
             ++x)
         {
           f(linear_data_range{
-              linear_id<3>::get(id<3>{x,_offset.get(1),_offset.get(2)},_shape),
+              linear_id<3>::get(sycl::id<3>{x,_offset.get(1),_offset.get(2)},_shape),
               _access_range.get(1) * _access_range.get(2)
             });
         }
@@ -217,7 +217,7 @@ private:
             ++y)
         {
           f(linear_data_range{
-              linear_id<3>::get(id<3>{x,y,_offset.get(2)},_shape),
+              linear_id<3>::get(sycl::id<3>{x,y,_offset.get(2)},_shape),
               _access_range.get(2)
             });
         }

--- a/include/CL/sycl/detail/stream.hpp
+++ b/include/CL/sycl/detail/stream.hpp
@@ -79,6 +79,9 @@ public:
   /// \return The error handler associated with this
   /// stream
   async_handler get_error_handler() const;
+
+  /// \return The device to which this stream is bound
+  device get_device() const;
 private:
   hipStream_t _stream;
 

--- a/include/CL/sycl/detail/thread_hierarchy.hpp
+++ b/include/CL/sycl/detail/thread_hierarchy.hpp
@@ -72,72 +72,72 @@ inline __device__ size_t get_global_size_z()
 
 template<int dimensions>
 __device__
-id<dimensions> get_local_id();
+sycl::id<dimensions> get_local_id();
 
 template<>
 __device__
-inline id<1> get_local_id<1>()
-{ return id<1>{hipThreadIdx_x}; }
+inline sycl::id<1> get_local_id<1>()
+{ return sycl::id<1>{hipThreadIdx_x}; }
 
 template<>
 __device__
-inline id<2> get_local_id<2>()
-{ return id<2>{hipThreadIdx_x, hipThreadIdx_y}; }
+inline sycl::id<2> get_local_id<2>()
+{ return sycl::id<2>{hipThreadIdx_x, hipThreadIdx_y}; }
 
 template<>
 __device__
-inline id<3> get_local_id<3>()
-{ return id<3>{hipThreadIdx_x, hipThreadIdx_y, hipThreadIdx_z}; }
+inline sycl::id<3> get_local_id<3>()
+{ return sycl::id<3>{hipThreadIdx_x, hipThreadIdx_y, hipThreadIdx_z}; }
 
 template<int dimensions>
 __device__
-id<dimensions> get_global_id();
+sycl::id<dimensions> get_global_id();
 
 template<>
 __device__
-inline id<1> get_global_id<1>()
-{ return id<1>{get_global_id_x()}; }
+inline sycl::id<1> get_global_id<1>()
+{ return sycl::id<1>{get_global_id_x()}; }
 
 template<>
 __device__
-inline id<2> get_global_id<2>()
+inline sycl::id<2> get_global_id<2>()
 {
-  return id<2>{get_global_id_x(), get_global_id_y()};
+  return sycl::id<2>{get_global_id_x(), get_global_id_y()};
 }
 
 template<>
 __device__
-inline id<3> get_global_id<3>()
+inline sycl::id<3> get_global_id<3>()
 {
-  return id<3>{get_global_id_x(),
-               get_global_id_y(),
-               get_global_id_z()};
+  return sycl::id<3>{get_global_id_x(),
+                    get_global_id_y(),
+                    get_global_id_z()};
 }
 
 template<int dimensions>
 __device__
-id<dimensions> get_group_id();
+sycl::id<dimensions> get_group_id();
 
 template<>
 __device__
-inline id<1> get_group_id<1>()
-{ return id<1>{hipBlockIdx_x}; }
+inline sycl::id<1> get_group_id<1>()
+{ return sycl::id<1>{hipBlockIdx_x}; }
 
 template<>
 __device__
-inline id<2> get_group_id<2>()
+inline sycl::id<2> get_group_id<2>()
 {
-  return id<2>{hipBlockIdx_x,
+  return sycl::id<2>{hipBlockIdx_x,
                hipBlockIdx_y};
 }
 
 template<>
 __device__
-inline id<3> get_group_id<3>()
+inline sycl::id<3> get_group_id<3>()
 {
-  return id<3>{hipBlockIdx_x,
-               hipBlockIdx_y,
-               hipBlockIdx_z};
+  return sycl::id<3>{hipBlockIdx_x,
+                    hipBlockIdx_y,
+                    hipBlockIdx_z};
 }
 
 template<int dimensions>

--- a/include/CL/sycl/group.hpp
+++ b/include/CL/sycl/group.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
  *
- * Copyright (c) 2018 Aksel Alpay
+ * Copyright (c) 2018,2019 Aksel Alpay
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -47,125 +47,182 @@ struct group
   HIPSYCL_KERNEL_TARGET
   id<dimensions> get_id() const
   {
-#ifdef __HIPSYCL_DEVICE_CALLABLE__
+#ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
     return detail::get_group_id<dimensions>();
 #else
-    return detail::invalid_host_call_dummy_return<id<dimensions>>();
+    return _group_id;
 #endif
   }
 
   HIPSYCL_KERNEL_TARGET
   size_t get_id(int dimension) const
   {
-#ifdef __HIPSYCL_DEVICE_CALLABLE__
+#ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
     return detail::get_group_id(dimension);
 #else
-    return detail::invalid_host_call_dummy_return<size_t>();
+    return _group_id[dimension];
 #endif
   }
 
   HIPSYCL_KERNEL_TARGET
   range<dimensions> get_global_range() const
   {
-#ifdef __HIPSYCL_DEVICE_CALLABLE__
+#ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
     return detail::get_global_size<dimensions>();
 #else
-    return detail::invalid_host_call_dummy_return<range<dimensions>>();
+    return _num_groups * _local_range;
 #endif
   }
 
   HIPSYCL_KERNEL_TARGET
   size_t get_global_range(int dimension) const
   {
-#ifdef __HIPSYCL_DEVICE_CALLABLE__
+#ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
     return detail::get_global_size(dimension);
 #else
-    return detail::invalid_host_call_dummy_return<size_t>();
+    return _num_groups[dimension] * _local_range[dimension];
 #endif
   }
 
+  /// \return The physical local range for flexible work group sizes,
+  /// the logical local range otherwise.
   HIPSYCL_KERNEL_TARGET
   range<dimensions> get_local_range() const
   {
-#ifdef __HIPSYCL_DEVICE_CALLABLE__
+#ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
     return detail::get_local_size<dimensions>();
 #else
-    return detail::invalid_host_call_dummy_return<range<dimensions>>();
+    return _local_range;
 #endif
   }
 
   HIPSYCL_KERNEL_TARGET
   size_t get_local_range(int dimension) const
   {
-#ifdef __HIPSYCL_DEVICE_CALLABLE__
+#ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
     return detail::get_local_size(dimension);
 #else
-    return detail::invalid_host_call_dummy_return<size_t>();
+    return _local_range[dimension];
 #endif
   }
 
   // Note: This returns the number of groups
-  // in each dimension - the spec wrongly claims that it should
-  // return the range "of the current group", i.e. the local range
-  // which makes no sense.
+  // in each dimension - earler versions of the spec wrongly 
+  // claim that it should return the range "of the current group", 
+  // i.e. the local range which makes no sense.
   HIPSYCL_KERNEL_TARGET
   range<dimensions> get_group_range() const
   {
-#ifdef __HIPSYCL_DEVICE_CALLABLE__
+#ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
     return detail::get_grid_size<dimensions>();
 #else
-    return detail::invalid_host_call_dummy_return<range<dimensions>>();
+    return _num_groups;
 #endif
   }
 
   HIPSYCL_KERNEL_TARGET
   size_t get_group_range(int dimension) const
   {
-#ifdef __HIPSYCL_DEVICE_CALLABLE__
+#ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
     return detail::get_grid_size(dimension);
 #else
-    return detail::invalid_host_call_dummy_return<size_t>();
+    return _num_groups[dimension];
 #endif
   }
 
   HIPSYCL_KERNEL_TARGET
   size_t operator[](int dimension) const
   {
-#ifdef __HIPSYCL_DEVICE_CALLABLE__
+#ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
     return detail::get_group_id(dimension);
 #else
-    return detail::invalid_host_call_dummy_return<size_t>();
+    return _group_id[dimension];
 #endif
   }
 
   HIPSYCL_KERNEL_TARGET
   size_t get_linear() const
   {
-#ifdef __HIPSYCL_DEVICE_CALLABLE__
     return detail::linear_id<dimensions>::get(get_id(),
                                               get_group_range());
-#else
-    return detail::invalid_host_call_dummy_return<size_t>();
-#endif
   }
 
   template<typename workItemFunctionT>
   HIPSYCL_KERNEL_TARGET
   void parallel_for_work_item(workItemFunctionT func) const
   {
-    h_item<dimensions> idx;
+#ifdef SYCL_DEVICE_ONLY
+  #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
+    h_item<dimensions> idx{detail::get_local_id<dimensions>(), detail::get_local_size<dimensions>()};
+  #else
+    h_item<dimensions> idx{detail::get_local_id<dimensions>(), _local_range, _group_id, _num_groups};
+  #endif
     func(idx);
     // We need implicit synchonization semantics
     mem_fence();
+#else
+    const range<3> range3d = detail::range::range_cast<3>(_local_range);
+
+  #ifndef HIPCPU_NO_OPENMP
+    #pragma omp simd
+  #endif
+    for(size_t i = 0; i < range3d.get(0); ++i)
+      for(size_t j = 0; j < range3d.get(1); ++j)
+        for(size_t k = 0; k < range3d.get(2); ++k)
+        {
+          h_item<dimensions> idx{
+            detail::id::construct_from_first_n<dimensions>(i,j,k),
+            _local_range, _group_id, _num_groups
+          };
+          func(idx);
+        }
+    // No memfence is needed here, because on CPU we only have one physical thread per work group.
+#endif
   }
 
-  /// \todo Flexible ranges are currently unsupported.
-  /*
   template<typename workItemFunctionT>
-  __device__
+  HIPSYCL_KERNEL_TARGET
   void parallel_for_work_item(range<dimensions> flexibleRange,
-                              workItemFunctionT func) const;
-  */
+                              workItemFunctionT func) const
+  {
+    const range<3> logical_range3d = detail::range::range_cast<3>(flexibleRange);
+
+#ifdef SYCL_DEVICE_ONLY
+    const range<3> physical_range3d = detail::range::range_cast<3>(this->get_local_range());
+    for(size_t i = 0; i < logical_range3d.get(0); i += physical_range3d.get(0))
+      for(size_t j = 0; j < logical_range3d.get(1); j += physical_range3d.get(1))
+        for(size_t k = 0; k < logical_range3d.get(2); k += physical_range3d.get(2))
+        {
+  #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
+          h_item<dimensions> idx{
+            detail::id::construct_from_first_n<dimensions>(i,j,k), flexibleRange};
+  #else
+          h_item<dimensions> idx{
+            detail::id::construct_from_first_n<dimensions>(i,j,k), 
+            flexibleRange, _group_id, _num_groups
+          };
+  #endif
+          func(idx);
+        }
+    mem_fence();
+#else
+  #ifndef HIPCPU_NO_OPENMP
+    #pragma omp simd 
+  #endif
+    for(size_t i = 0; i < logical_range3d.get(0); ++i)
+      for(size_t j = 0; j < logical_range3d.get(1); ++j)
+        for(size_t k = 0; k < logical_range3d.get(2); ++k)
+        {
+          h_item<dimensions> idx{
+            detail::id::construct_from_first_n<dimensions>(i,j,k), 
+            flexibleRange, _group_id, _num_groups
+          };
+
+          func(idx);
+        }
+    // No memfence is needed here, because on CPU we only have one physical thread per work group.
+#endif
+  }
 
 
   template <access::mode accessMode = access::mode::read_write>
@@ -173,10 +230,10 @@ struct group
   void mem_fence(access::fence_space accessSpace =
       access::fence_space::global_and_local) const
   {
-#ifdef __HIPSYCL_DEVICE_CALLABLE__
+    // On CPU, mem_fence() can be skipped since there is only one physical thread
+    // per work group
+#ifdef SYCL_DEVICE_ONLY
     __syncthreads();
-#else
-    detail::invalid_host_call();
 #endif
   }
 
@@ -186,8 +243,16 @@ struct group
   device_event async_work_group_copy(local_ptr<dataT> dest,
                                      global_ptr<dataT> src, size_t numElements) const
   {
-    size_t local_size = get_local_range().size();
-    for(size_t i = get_linear(); i < numElements; i += local_size)
+#ifdef SYCL_DEVICE_ONLY
+    const size_t physical_local_size = get_local_range().size();
+#else
+    const size_t physical_local_size = 1;
+#endif
+
+#ifndef HIPCPU_NO_OPENMP
+  #pragma omp simd
+#endif
+    for(size_t i = get_linear(); i < numElements; i += physical_local_size)
       dest[i] = src[i];
     mem_fence();
 
@@ -199,8 +264,16 @@ struct group
   device_event async_work_group_copy(global_ptr<dataT> dest,
                                      local_ptr<dataT> src, size_t numElements) const
   {
-    size_t local_size = get_local_range().size();
-    for(size_t i = get_linear(); i < numElements; i += local_size)
+#ifdef SYCL_DEVICE_ONLY
+    const size_t physical_local_size = get_local_range().size();
+#else
+    const size_t physical_local_size = 1;
+#endif
+
+#ifndef HIPCPU_NO_OPENMP
+  #pragma omp simd
+#endif
+    for(size_t i = get_linear(); i < numElements; i += physical_local_size)
       dest[i] = src[i];
     mem_fence();
 
@@ -212,8 +285,16 @@ struct group
   device_event async_work_group_copy(local_ptr<dataT> dest,
                                      global_ptr<dataT> src, size_t numElements, size_t srcStride) const
   {
-    size_t local_size = get_local_range().size();
-    for(size_t i = get_linear(); i < numElements; i += local_size)
+#ifdef SYCL_DEVICE_ONLY
+    const size_t physical_local_size = get_local_range().size();
+#else
+    const size_t physical_local_size = 1;
+#endif
+
+#ifndef HIPCPU_NO_OPENMP
+  #pragma omp simd
+#endif
+    for(size_t i = get_linear(); i < numElements; i += physical_local_size)
       dest[i] = src[i * srcStride];
     mem_fence();
 
@@ -225,8 +306,16 @@ struct group
   device_event async_work_group_copy(global_ptr<dataT> dest,
                                      local_ptr<dataT> src, size_t numElements, size_t destStride) const
   {
-    size_t local_size = get_local_range().size();
-    for(size_t i = get_linear(); i < numElements; i += local_size)
+#ifdef SYCL_DEVICE_ONLY
+    const size_t physical_local_size = get_local_range().size();
+#else
+    const size_t physical_local_size = 1;
+#endif
+
+#ifndef HIPCPU_NO_OPENMP
+  #pragma omp simd
+#endif
+    for(size_t i = get_linear(); i < numElements; i += physical_local_size)
       dest[i * destStride] = src[i];
     mem_fence();
 
@@ -237,7 +326,20 @@ struct group
   HIPSYCL_KERNEL_TARGET
   void wait_for(eventTN...) const {}
 
-  //group(id<dimensions>* offset) = default;
+#if !defined(HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO)
+  group(id<dimensions> group_id,
+        range<dimensions> local_range,
+        range<dimensions> num_groups)
+  : _group_id{group_id}, 
+    _local_range{local_range}, 
+    _num_groups{num_groups}
+  {}
+
+private:
+  const id<dimensions> _group_id;
+  const range<dimensions> _local_range;
+  const range<dimensions> _num_groups;
+#endif
 };
 
 }

--- a/include/CL/sycl/handler.hpp
+++ b/include/CL/sycl/handler.hpp
@@ -59,17 +59,11 @@ namespace detail {
 namespace dispatch {
 
 
-template<class Function>
-__sycl_kernel void single_task_kernel(Function f)
-{
-  f();
-}
-
 template<int dimensions, bool with_offset>
 HIPSYCL_KERNEL_TARGET
-bool item_is_in_range(const item<dimensions, with_offset>& item,
+bool item_is_in_range(const sycl::item<dimensions, with_offset>& item,
                       const sycl::range<dimensions>& execution_range,
-                      const id<dimensions>& offset)
+                      const sycl::id<dimensions>& offset)
 {
   for(int i = 0; i < dimensions; ++i)
   {
@@ -81,20 +75,73 @@ bool item_is_in_range(const item<dimensions, with_offset>& item,
   return true;
 }
 
-// This helper function is necessary because we cannot
+
+namespace device {
+
+// These helper functions are necessary because we cannot
 // call device functions directly from __sycl_kernel functions
 // with the clang plugin, since they are initially treated
 // as host functions.
 // TODO: Find a nicer solution for that.
 template<int dimensions>
 HIPSYCL_KERNEL_TARGET
-inline id<dimensions> get_global_id_helper()
+inline sycl::id<dimensions> get_global_id_helper()
 {
 #ifdef __HIPSYCL_DEVICE_CALLABLE__
   return detail::get_global_id<dimensions>();
 #else
-  return detail::invalid_host_call_dummy_return<id<dimensions>>();
+  return detail::invalid_host_call_dummy_return<sycl::id<dimensions>>();
 #endif
+}
+
+template<int dimensions>
+HIPSYCL_KERNEL_TARGET
+inline sycl::id<dimensions> get_local_id_helper()
+{
+#ifdef __HIPSYCL_DEVICE_CALLABLE__
+  return detail::get_local_id<dimensions>();
+#else
+  return detail::invalid_host_call_dummy_return<sycl::id<dimensions>>();
+#endif
+}
+
+template<int dimensions>
+HIPSYCL_KERNEL_TARGET
+inline sycl::id<dimensions> get_group_id_helper()
+{
+#ifdef __HIPSYCL_DEVICE_CALLABLE__
+  return detail::get_group_id<dimensions>();
+#else
+  return detail::invalid_host_call_dummy_return<sycl::id<dimensions>>();
+#endif
+}
+
+template<int dimensions>
+HIPSYCL_KERNEL_TARGET
+inline sycl::range<dimensions> get_local_size_helper()
+{
+#ifdef __HIPSYCL_DEVICE_CALLABLE__
+  return detail::get_local_size<dimensions>();
+#else
+  return detail::invalid_host_call_dummy_return<sycl::range<dimensions>>();
+#endif
+}
+
+template<int dimensions>
+HIPSYCL_KERNEL_TARGET
+inline sycl::range<dimensions> get_grid_size_helper()
+{
+#ifdef __HIPSYCL_DEVICE_CALLABLE__
+  return detail::get_grid_size<dimensions>();
+#else
+  return detail::invalid_host_call_dummy_return<sycl::range<dimensions>>();
+#endif
+}
+
+template<class Function>
+__sycl_kernel void single_task_kernel(Function f)
+{
+  f();
 }
 
 template<int dimensions, class Function>
@@ -104,7 +151,7 @@ void parallel_for_kernel(Function f,
 {
   auto this_item = detail::make_item<dimensions>(
     get_global_id_helper<dimensions>(), execution_range);
-  if(item_is_in_range(this_item, execution_range, id<dimensions>{}))
+  if(item_is_in_range(this_item, execution_range, sycl::id<dimensions>{}))
     f(this_item);
 }
 
@@ -112,30 +159,235 @@ template<int dimensions, class Function>
 __sycl_kernel 
 void parallel_for_kernel_with_offset(Function f,
                                     sycl::range<dimensions> execution_range,
-                                    id<dimensions> offset)
+                                    sycl::id<dimensions> offset)
 {
   auto this_item = detail::make_item<dimensions>(
-    get_global_id_helper<dimensions>(), execution_range, offset);
+    get_global_id_helper<dimensions>() + offset, execution_range, offset);
   if(item_is_in_range(this_item, execution_range, offset))
     f(this_item);
 }
 
 template<int dimensions, class Function>
 __sycl_kernel
-void parallel_for_ndrange_kernel(Function f, id<dimensions> offset)
+void parallel_for_ndrange_kernel(Function f, sycl::id<dimensions> offset)
 {
+#ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
   nd_item<dimensions> this_item{&offset};
+#else
+  nd_item<dimensions> this_item{
+    &offset, 
+    get_group_id_helper<dimensions>(), 
+    get_local_id_helper<dimensions>(),
+    get_local_size_helper<dimensions>(),
+    get_grid_size_helper<dimensions>()
+  };
+#endif
   f(this_item);
 }
 
 template<int dimensions, class Function>
 __sycl_kernel 
 void parallel_for_workgroup(Function f,
-                            sycl::range<dimensions> work_group_size)
+                            // The logical group size is not yet used,
+                            // but it's still useful to already have it here
+                            // since it allows the compiler to infer 'dimensions'
+                            sycl::range<dimensions> logical_group_size)
 {
+#ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
   group<dimensions> this_group;
+#else
+  group<dimensions> this_group{
+    get_group_id_helper<dimensions>(), 
+    get_local_size_helper<dimensions>(),
+    get_grid_size_helper<dimensions>()
+  };
+#endif
   f(this_group);
 }
+
+} // device
+
+namespace host {
+
+#ifdef HIPSYCL_PLATFORM_CPU
+
+namespace offset{
+struct with_offset{};
+struct without_offset{};
+}
+
+template<int dimensions>
+inline item<dimensions, true> make_item_maybe_with_offset(
+                    sycl::id<dimensions> effective_id, 
+                    sycl::range<dimensions> size,
+                    sycl::id<dimensions> offset,
+                    offset::with_offset)
+{
+  return make_item(effective_id, size, offset);
+}
+
+template<int dimensions>
+inline item<dimensions, true> make_item_maybe_with_offset(
+                    sycl::id<dimensions> effective_id, 
+                    sycl::range<dimensions> size,
+                    sycl::id<dimensions> offset,
+                    offset::without_offset)
+{
+  return make_item(effective_id, size);
+}
+
+
+// On CPU, we can use references for the kernel lambdas. This is because
+// they are already copied as a closure to the task graph, which already
+// stores all necessary captures etc until the lambda is executed.
+template<class Function>
+inline 
+void single_task_kernel(Function&& f)
+{
+  f();
+}
+
+template<class Function, class Offset_mode> 
+inline 
+void parallel_for_kernel(Function&& f,
+                        const sycl::range<1> execution_range,
+                        Offset_mode,
+                        const sycl::id<1> offset = sycl::id<1>{})
+{
+  const size_t max_id = offset.get(0) + execution_range.get(0);
+
+#ifndef HIPCPU_NO_OPENMP
+  #pragma omp parallel for
+#endif
+  for(size_t i = offset.get(0); i < max_id; ++i)
+  {
+    auto this_item = 
+      make_item_maybe_with_offset(sycl::id<1>{i}, 
+                                  execution_range,
+                                  offset, Offset_mode{});
+
+    f(this_item);
+  }
+}
+
+template<class Function, class Offset_mode> 
+inline 
+void parallel_for_kernel(Function&& f,
+                        const sycl::range<2> execution_range,
+                        Offset_mode,
+                        const sycl::id<2> offset = sycl::id<2>{})
+{
+  const sycl::id<2> max_id = offset + execution_range;
+
+#ifndef HIPCPU_NO_OPENMP
+  #pragma omp parallel for collapse(2)
+#endif
+  for(size_t i = offset.get(0); i < max_id.get(0); ++i)
+    for(size_t j = offset.get(1); j < max_id.get(1); ++j)
+    {
+      auto this_item = 
+        make_item_maybe_with_offset(sycl::id<2>{i,j}, 
+                                    execution_range, 
+                                    offset, Offset_mode{});
+
+      f(this_item);
+    }
+}
+
+template<class Function, class Offset_mode> 
+inline 
+void parallel_for_kernel(Function&& f,
+                        const sycl::range<3> execution_range,
+                        Offset_mode,
+                        const sycl::id<3> offset = sycl::id<3>{})
+{
+  const sycl::id<3> max_id = offset + execution_range;
+
+#ifndef HIPCPU_NO_OPENMP
+  #pragma omp parallel for collapse(3)
+#endif
+  for(size_t i = offset.get(0); i < max_id.get(0); ++i)
+    for(size_t j = offset.get(1); j < max_id.get(1); ++j)
+      for(size_t k = offset.get(2); k < max_id.get(2); ++k)
+    {
+      auto this_item = 
+        make_item_maybe_with_offset(sycl::id<3>{i,j,k}, 
+                                    execution_range, 
+                                    offset, Offset_mode{});
+        
+      f(this_item);
+    }
+}
+
+// This must still be executed by hipCPU's hipLaunchKernel for correct
+// synchronization semantics
+template<int dimensions, class Function>
+inline
+void parallel_for_ndrange_kernel(Function&& f, sycl::id<dimensions> offset)
+{
+  nd_item<dimensions> this_item{
+    &offset,
+    detail::get_group_id<dimensions>(),
+    detail::get_local_id<dimensions>(),
+    detail::get_local_size<dimensions>(),
+    detail::get_grid_size<dimensions>()
+  };
+  f(this_item);
+}
+
+template<class Function>
+inline 
+void parallel_for_workgroup(Function&& f,
+                            const sycl::range<1> num_groups,
+                            const sycl::range<1> local_size)
+{
+#ifndef HIPCPU_NO_OPENMP
+  #pragma omp parallel for
+#endif
+  for(size_t i = 0; i < num_groups.get(0); ++i)
+  {
+    group<1> this_group{sycl::id<1>{i}, local_size, num_groups};
+    f(this_group);
+  }
+}
+
+template<class Function>
+inline 
+void parallel_for_workgroup(Function&& f,
+                            const sycl::range<2> num_groups,
+                            const sycl::range<2> local_size)
+{
+#ifndef HIPCPU_NO_OPENMP
+  #pragma omp parallel for collapse(2)
+#endif
+  for(size_t i = 0; i < num_groups.get(0); ++i)
+    for(size_t j = 0; j < num_groups.get(1); ++j)
+    {
+      group<2> this_group{sycl::id<2>{i,j}, local_size, num_groups};
+      f(this_group);
+    }
+}
+
+template<class Function>
+inline 
+void parallel_for_workgroup(Function&& f,
+                            const sycl::range<3> num_groups,
+                            const sycl::range<3> local_size)
+{
+#ifndef HIPCPU_NO_OPENMP
+  #pragma omp parallel for collapse(3)
+#endif
+  for(size_t i = 0; i < num_groups.get(0); ++i)
+    for(size_t j = 0; j < num_groups.get(1); ++j)
+      for(size_t k = 0; k < num_groups.get(2); ++k)
+      {
+        group<3> this_group{sycl::id<3>{i,j,k}, local_size, num_groups};
+        f(this_group);
+      }
+}
+
+#endif // HIPSYCL_PLATFORM_CPU
+} // host
 
 } // dispatch
 
@@ -155,6 +407,7 @@ constexpr hipMemcpyKind get_copy_kind()
   assert(false && "Unsupported / unimplemented access targets");
   return hipMemcpyDefault;
 }
+
 
 } // detail
 
@@ -212,9 +465,25 @@ void set_args(Ts &&... args);
         -> detail::task_state
     {
       stream->activate_device();
-      __hipsycl_launch_kernel(detail::dispatch::single_task_kernel,
-                              1,1,shared_mem_size,stream->get_stream(),
-                              kernelFunc);
+
+      // Legacy toolchain does not support __host__ __device__
+      // kernel, also we cannot yet enable runtime selection
+      // of backends due to name collisions between hipCPU and
+      // actual HIP
+#ifdef HIPSYCL_ENABLE_HOST_KERNEL_INVOCATION
+      if(stream->get_device().is_host())
+      {
+        hipLaunchSequentialKernel(detail::dispatch::host::single_task_kernel,
+                                  stream->get_stream(), shared_mem_size,
+                                  kernelFunc);
+      }
+      else
+#endif
+      {
+        __hipsycl_launch_kernel(detail::dispatch::device::single_task_kernel,
+                                1,1,shared_mem_size,stream->get_stream(),
+                                kernelFunc);
+      }
 
       return detail::task_state::enqueued;
     };
@@ -555,9 +824,21 @@ private:
     {
       stream->activate_device();
 
-      __hipsycl_launch_kernel(detail::dispatch::parallel_for_kernel,
-                            grid, block, shared_mem_size, stream->get_stream(),
-                            kernelFunc, numWorkItems);
+#ifdef HIPSYCL_ENABLE_HOST_KERNEL_INVOCATION
+      if(stream->get_device().is_host())
+      {
+        hipLaunchSequentialKernel(detail::dispatch::host::parallel_for_kernel,
+                                  stream->get_stream(), shared_mem_size,
+                                  kernelFunc, numWorkItems, 
+                                  detail::dispatch::host::offset::without_offset{});
+      }
+      else
+#endif
+      {
+        __hipsycl_launch_kernel(detail::dispatch::device::parallel_for_kernel,
+                              grid, block, shared_mem_size, stream->get_stream(),
+                              kernelFunc, numWorkItems);
+      }
 
       return detail::task_state::enqueued;
     };
@@ -586,10 +867,22 @@ private:
     {
       stream->activate_device();
 
-      __hipsycl_launch_kernel(detail::dispatch::parallel_for_kernel_with_offset,
+#ifdef HIPSYCL_ENABLE_HOST_KERNEL_INVOCATION
+      if(stream->get_device().is_host())
+      {
+        hipLaunchSequentialKernel(detail::dispatch::host::parallel_for_kernel,
+                                  stream->get_stream(), shared_mem_size,
+                                  kernelFunc, numWorkItems, 
+                                  detail::dispatch::host::offset::with_offset{}, 
+                                  offset);
+      }
+      else
+#endif
+      {
+        __hipsycl_launch_kernel(detail::dispatch::device::parallel_for_kernel_with_offset,
                         grid, block, shared_mem_size, stream->get_stream(),
                         kernelFunc, numWorkItems, offset);
-
+      }
 
       return detail::task_state::enqueued;
     };
@@ -625,10 +918,23 @@ private:
     {
       stream->activate_device();
 
-      __hipsycl_launch_kernel(detail::dispatch::parallel_for_ndrange_kernel,
-                        grid, block, shared_mem_size, stream->get_stream(),
-                        kernelFunc, offset);
-
+#ifdef HIPSYCL_ENABLE_HOST_KERNEL_INVOCATION
+      if(stream->get_device().is_host())
+      {
+        // We still need the hipCPU kernel launch semantics
+        // for ndrange kernels until we have support in the clang
+        // plugin for dealing with barriers
+        __hipsycl_launch_kernel(detail::dispatch::host::parallel_for_ndrange_kernel,
+                          grid, block, shared_mem_size, stream->get_stream(),
+                          kernelFunc, offset);
+      }
+      else
+#endif
+      {
+        __hipsycl_launch_kernel(detail::dispatch::device::parallel_for_ndrange_kernel,
+                          grid, block, shared_mem_size, stream->get_stream(),
+                          kernelFunc, offset);
+      }
 
       return detail::task_state::enqueued;
     };
@@ -656,9 +962,20 @@ private:
     {
       stream->activate_device();
 
-      __hipsycl_launch_kernel(detail::dispatch::parallel_for_workgroup,
-                        grid, block, shared_mem_size, stream->get_stream(),
-                        kernelFunc, workGroupSize);
+#ifdef HIPSYCL_ENABLE_HOST_KERNEL_INVOCATION
+      if(stream->get_device().is_host())
+      {
+        hipLaunchSequentialKernel(detail::dispatch::host::parallel_for_workgroup,
+                                  stream->get_stream(), shared_mem_size,
+                                  kernelFunc, numWorkGroups, workGroupSize);
+      }
+      else
+#endif
+      {
+        __hipsycl_launch_kernel(detail::dispatch::device::parallel_for_workgroup,
+                          grid, block, shared_mem_size, stream->get_stream(),
+                          kernelFunc, workGroupSize);
+      }
 
 
       return detail::task_state::enqueued;

--- a/include/CL/sycl/handler.hpp
+++ b/include/CL/sycl/handler.hpp
@@ -242,17 +242,17 @@ inline item<dimensions, true> make_item_maybe_with_offset(
 // stores all necessary captures etc until the lambda is executed.
 template<class Function>
 inline 
-void single_task_kernel(Function&& f)
+void single_task_kernel(Function&& f) noexcept
 {
   f();
 }
 
 template<class Function, class Offset_mode> 
-inline 
+inline
 void parallel_for_kernel(Function&& f,
                         const sycl::range<1> execution_range,
                         Offset_mode,
-                        const sycl::id<1> offset = sycl::id<1>{})
+                        const sycl::id<1> offset = sycl::id<1>{}) noexcept
 {
   const size_t max_id = offset.get(0) + execution_range.get(0);
 
@@ -275,7 +275,7 @@ inline
 void parallel_for_kernel(Function&& f,
                         const sycl::range<2> execution_range,
                         Offset_mode,
-                        const sycl::id<2> offset = sycl::id<2>{})
+                        const sycl::id<2> offset = sycl::id<2>{}) noexcept
 {
   const sycl::id<2> max_id = offset + execution_range;
 
@@ -299,7 +299,7 @@ inline
 void parallel_for_kernel(Function&& f,
                         const sycl::range<3> execution_range,
                         Offset_mode,
-                        const sycl::id<3> offset = sycl::id<3>{})
+                        const sycl::id<3> offset = sycl::id<3>{}) noexcept
 {
   const sycl::id<3> max_id = offset + execution_range;
 
@@ -323,7 +323,7 @@ void parallel_for_kernel(Function&& f,
 // synchronization semantics
 template<int dimensions, class Function>
 inline
-void parallel_for_ndrange_kernel(Function&& f, sycl::id<dimensions> offset)
+void parallel_for_ndrange_kernel(Function&& f, sycl::id<dimensions> offset) noexcept
 {
   nd_item<dimensions> this_item{
     &offset,
@@ -343,7 +343,7 @@ inline
 void parallel_for_workgroup(Function&& f,
                             const sycl::range<1> num_groups,
                             const sycl::range<1> local_size,
-                            size_t num_local_mem_bytes)
+                            size_t num_local_mem_bytes) noexcept
 {
 #ifndef HIPCPU_NO_OPENMP
   #pragma omp parallel
@@ -369,7 +369,7 @@ inline
 void parallel_for_workgroup(Function&& f,
                             const sycl::range<2> num_groups,
                             const sycl::range<2> local_size,
-                            size_t num_local_mem_bytes)
+                            size_t num_local_mem_bytes) noexcept
 {
 #ifndef HIPCPU_NO_OPENMP
   #pragma omp parallel
@@ -396,7 +396,7 @@ inline
 void parallel_for_workgroup(Function&& f,
                             const sycl::range<3> num_groups,
                             const sycl::range<3> local_size,
-                            size_t num_local_mem_bytes)
+                            size_t num_local_mem_bytes) noexcept
 {
 #ifndef HIPCPU_NO_OPENMP
   #pragma omp parallel

--- a/include/CL/sycl/id.hpp
+++ b/include/CL/sycl/id.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
  *
- * Copyright (c) 2018 Aksel Alpay
+ * Copyright (c) 2018,2019 Aksel Alpay
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -243,6 +243,32 @@ HIPSYCL_ID_BINARY_OP_SIZE_T(>>)
 HIPSYCL_ID_BINARY_OP_SIZE_T(&)
 HIPSYCL_ID_BINARY_OP_SIZE_T(|)
 HIPSYCL_ID_BINARY_OP_SIZE_T(^)
+
+namespace detail {
+namespace id{
+
+template<int dimensions>
+HIPSYCL_UNIVERSAL_TARGET
+inline sycl::id<dimensions> construct_from_first_n(size_t x, size_t y, size_t z);
+
+template<>
+HIPSYCL_UNIVERSAL_TARGET
+inline sycl::id<3> construct_from_first_n(size_t x, size_t y, size_t z)
+{ return sycl::id<3>{x,y,z}; }
+
+template<>
+HIPSYCL_UNIVERSAL_TARGET
+inline sycl::id<2> construct_from_first_n(size_t x, size_t y, size_t z)
+{ return sycl::id<2>{x,y}; }
+
+template<>
+HIPSYCL_UNIVERSAL_TARGET
+inline sycl::id<1> construct_from_first_n(size_t x, size_t y, size_t z)
+{ return sycl::id<1>{x}; }
+
+
+} // namespace id
+} // namespace detail
 
 } // namespace sycl
 } // namespace cl

--- a/include/CL/sycl/item.hpp
+++ b/include/CL/sycl/item.hpp
@@ -47,7 +47,7 @@ template <int dimensions>
 struct item_base
 {
   HIPSYCL_KERNEL_TARGET 
-  item_base(const id<dimensions>& my_id,
+  item_base(const sycl::id<dimensions>& my_id,
     const sycl::range<dimensions>& global_size)
     : global_id{my_id}, global_size(global_size)
   {}
@@ -62,84 +62,7 @@ struct item_base
   size_t get_range(int dimension) const
   { return global_size[dimension]; }
 
-protected:
-  id<dimensions> global_id;
-  sycl::range<dimensions> global_size;
-};
-
-template <int dimensions>
-HIPSYCL_KERNEL_TARGET
-item<dimensions, true> make_item(const id<dimensions>& my_id,
-  const sycl::range<dimensions>& global_size, const id<dimensions>& offset)
-{
-  return item<dimensions, true>{my_id, global_size, offset};
-}
-
-template <int dimensions>
-HIPSYCL_KERNEL_TARGET
-item<dimensions, false> make_item(const id<dimensions>& my_id,
-  const sycl::range<dimensions>& global_size)
-{
-  return item<dimensions, false>{my_id, global_size};
-}
-
-} // namespace detail
-
-template <int dimensions = 1, bool with_offset = true>
-struct item : detail::item_base<dimensions>
-{};
-
-template <int dimensions>
-struct item<dimensions, true> : detail::item_base<dimensions>
-{
-  /* -- common interface members -- */
-
-  HIPSYCL_KERNEL_TARGET id<dimensions> get_id() const
-  {
-    return this->global_id + offset;
-  }
-
-  HIPSYCL_KERNEL_TARGET size_t get_id(int dimension) const
-  {
-    return this->global_id[dimension] + offset[dimension];
-  }
-
-  HIPSYCL_KERNEL_TARGET size_t operator[](int dimension)
-  {
-    return this->global_id[dimension] + offset[dimension];
-  }
-
-  HIPSYCL_KERNEL_TARGET size_t get_linear_id() const
-  {
-    return detail::linear_id<dimensions>::get(this->global_id + offset,
-      this->global_size);
-  }
-
-  HIPSYCL_KERNEL_TARGET id<dimensions> get_offset() const
-  {
-    return offset;
-  }
-
-private:
-  template<int d>
-  using _range = sycl::range<d>; // workaround for nvcc
-  friend HIPSYCL_KERNEL_TARGET item<dimensions, true> detail::make_item<dimensions>(
-    const id<dimensions>&, const _range<dimensions>&, const id<dimensions>&);
-
-  HIPSYCL_KERNEL_TARGET item(const id<dimensions>& my_id,
-    const sycl::range<dimensions>& global_size, const id<dimensions>& offset)
-    : detail::item_base<dimensions>(my_id, global_size), offset{offset}
-  {}
-
-  const id<dimensions> offset;
-};
-
-template <int dimensions>
-struct item<dimensions, false> : detail::item_base<dimensions>
-{
-  /* -- common interface members -- */
-
-  HIPSYCL_KERNEL_TARGET id<dimensions> get_id() const
+  HIPSYCL_KERNEL_TARGET sycl::id<dimensions> get_id() const
   {
     return this->global_id;
   }
@@ -156,27 +79,83 @@ struct item<dimensions, false> : detail::item_base<dimensions>
 
   HIPSYCL_KERNEL_TARGET size_t get_linear_id() const
   {
-#ifdef __HIPSYCL_DEVICE_CALLABLE__
     return detail::linear_id<dimensions>::get(this->global_id,
       this->global_size);
-#else
-    return detail::invalid_host_call_dummy_return<size_t>();
-#endif
+  }
+protected:
+  sycl::id<dimensions> global_id;
+  sycl::range<dimensions> global_size;
+};
+
+/// Creates an Item with offset.
+/// \param my_effective_id This has to be global_id + offset.
+template <int dimensions>
+HIPSYCL_KERNEL_TARGET
+item<dimensions, true> make_item(const sycl::id<dimensions>& my_effective_id,
+  const sycl::range<dimensions>& global_size, const sycl::id<dimensions>& offset)
+{
+  return item<dimensions, true>{my_effective_id, global_size, offset};
+}
+
+/// Creates an Item without offset
+/// \param my_id This should equal global_id
+template <int dimensions>
+HIPSYCL_KERNEL_TARGET
+item<dimensions, false> make_item(const sycl::id<dimensions>& my_id,
+  const sycl::range<dimensions>& global_size)
+{
+  return item<dimensions, false>{my_id, global_size};
+}
+
+} // namespace detail
+
+template <int dimensions = 1, bool with_offset = true>
+struct item : detail::item_base<dimensions>
+{};
+
+template <int dimensions>
+struct item<dimensions, true> : detail::item_base<dimensions>
+{
+  HIPSYCL_KERNEL_TARGET sycl::id<dimensions> get_offset() const
+  {
+    return offset;
   }
 
+private:
+  template<int d>
+  using _range = sycl::range<d>; // workaround for nvcc
+
+  friend HIPSYCL_KERNEL_TARGET 
+  item<dimensions, true> detail::make_item<dimensions>(
+    const sycl::id<dimensions>&, const _range<dimensions>&, 
+    const sycl::id<dimensions>&);
+
+  HIPSYCL_KERNEL_TARGET 
+  item(const sycl::id<dimensions>& my_id,
+    const sycl::range<dimensions>& global_size, 
+    const sycl::id<dimensions>& offset)
+    : detail::item_base<dimensions>(my_id, global_size), offset{offset}
+  {}
+
+  const sycl::id<dimensions> offset;
+};
+
+template <int dimensions>
+struct item<dimensions, false> : detail::item_base<dimensions>
+{
   HIPSYCL_KERNEL_TARGET operator item<dimensions, true>() const
   {
     return detail::make_item<dimensions>(this->global_id, this->global_size,
-      id<dimensions>{});
+      sycl::id<dimensions>{});
   }
 
 private:
   template<int d>
   using _range = sycl::range<d>; // workaround for nvcc
   friend HIPSYCL_KERNEL_TARGET item<dimensions, false> detail::make_item<dimensions>(
-    const id<dimensions>&, const _range<dimensions>&);
+    const sycl::id<dimensions>&, const _range<dimensions>&);
 
-  HIPSYCL_KERNEL_TARGET item(const id<dimensions>& my_id,
+  HIPSYCL_KERNEL_TARGET item(const sycl::id<dimensions>& my_id,
     const sycl::range<dimensions>& global_size)
     : detail::item_base<dimensions>(my_id, global_size)
   {}

--- a/include/CL/sycl/range.hpp
+++ b/include/CL/sycl/range.hpp
@@ -244,6 +244,7 @@ inline sycl::range<1> omit_first_dimension(const sycl::range<2>& r)
 }
 
 template <int dimsOut, int dimsIn>
+HIPSYCL_UNIVERSAL_TARGET
 sycl::range<dimsOut> range_cast(const sycl::range<dimsIn>& other)
 {
   sycl::range<dimsOut> result;

--- a/src/hipsycl_clang_plugin/Frontend.hpp
+++ b/src/hipsycl_clang_plugin/Frontend.hpp
@@ -252,7 +252,7 @@ private:
       return;
 
     if(f->getQualifiedNameAsString() 
-        == "cl::sycl::detail::dispatch::parallel_for_workgroup")
+        == "cl::sycl::detail::dispatch::device::parallel_for_workgroup")
     {
       clang::FunctionDecl* Kernel = 
         this->getKernelFromHierarchicalParallelFor(f);

--- a/src/hipsycl_transform_source/CompilationTargetAnnotator.cpp
+++ b/src/hipsycl_transform_source/CompilationTargetAnnotator.cpp
@@ -179,13 +179,13 @@ CompilationTargetAnnotator::addAnnotations()
         if(caller && caller->getAsFunction())
         {
           std::string callerName = caller->getAsFunction()->getQualifiedNameAsString();
-          if(callerName.find("cl::sycl::detail::dispatch::") !=
+          if(callerName.find("cl::sycl::detail::dispatch::device::") !=
              std::string::npos)
           {
             // If this is a kernel function in a parallel hierarchical for,
             // we need to add __shared__ attributes. This is the case
-            // if the function is called by cl::sycl::detail::dispatch::parallel_for_workgroup
-            if(callerName == "cl::sycl::detail::dispatch::parallel_for_workgroup")
+            // if the function is called by cl::sycl::detail::dispatch::device::parallel_for_workgroup
+            if(callerName == "cl::sycl::detail::dispatch::device::parallel_for_workgroup")
               this->correctSharedMemoryAnnotations(decl.first);
 
             // In any way, mark all kernels as __device__ to

--- a/src/libhipSYCL/CMakeLists.txt
+++ b/src/libhipSYCL/CMakeLists.txt
@@ -12,7 +12,8 @@ set(HIPSYCL_SOURCES
   buffer.cpp
   task_graph.cpp
   accessor.cpp
-  async_worker.cpp)
+  async_worker.cpp
+  local_memory.cpp)
 
 
 set(INCLUDE_DIRS

--- a/src/libhipSYCL/local_memory.cpp
+++ b/src/libhipSYCL/local_memory.cpp
@@ -1,0 +1,39 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2018, 2019 Aksel Alpay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "CL/sycl/detail/local_memory_allocator.hpp"
+
+namespace cl {
+namespace sycl {
+namespace detail {
+
+char* host_local_memory::_local_mem = nullptr;
+char host_local_memory::_static_local_mem [host_local_memory::_max_static_local_mem_size] = {};
+host_local_memory_origin host_local_memory::_origin = host_local_memory_origin::custom_threadprivate;
+}
+}
+}

--- a/src/libhipSYCL/queue.cpp
+++ b/src/libhipSYCL/queue.cpp
@@ -87,6 +87,12 @@ async_handler stream_manager::get_error_handler() const
   return this->_handler;
 }
 
+
+device stream_manager::get_device() const
+{
+  return this->_dev; 
+}
+
 }
 
 

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -107,7 +107,7 @@ BOOST_AUTO_TEST_CASE(basic_parallel_for_nd) {
       cl::sycl::range<1>(group_size)};
     cgh.parallel_for<class basic_parallel_for_nd>(kernel_range,
       [=](cl::sycl::nd_item<1> tid) {
-        acc[tid.get_global()[0]] = tid.get_group(0);
+        acc[tid.get_global_id()[0]] = tid.get_group(0);
       });
   });
   auto acc = buf.get_access<cl::sycl::access::mode::read>();
@@ -181,14 +181,14 @@ BOOST_AUTO_TEST_CASE(dynamic_local_memory) {
       cgh.parallel_for<class dynamic_local_memory_reduction>(
         cl::sycl::nd_range<1>{global_size, local_size},
         [=](cl::sycl::nd_item<1> item) {
-          const auto lid = item.get_local(0);
-          scratch[lid] = acc[item.get_global()];
+          const auto lid = item.get_local_id(0);
+          scratch[lid] = acc[item.get_global_id()];
           item.barrier();
           for(size_t i = local_size/2; i > 0; i /= 2) {
             if(lid < i) scratch[lid] += scratch[lid + i];
             item.barrier();
           }
-          if(lid == 0) acc[item.get_global()] = scratch[0];
+          if(lid == 0) acc[item.get_global_id()] = scratch[0];
         });
     });
   }


### PR DESCRIPTION
Currently, we rely entirely on hipCPU for parallelization and execution on CPU. Since `__syncthreads()` can occur at any time, hipCPU has to spawn as many threads as there are work items in a group to guarantee correct barrier semantics.
This is (usually) massively inefficient. Since there are many varieties of kernel invocations in SYCL where no barriers can occur, we have more flexibility in this regard than hipCPU.

This PR implements a rework of the CPU execution model to use OpenMP multithreading across work groups (instead of work items), potentially combined with (hopefully vectorized) inner loops over the work items and should eliminate this massive performance issue for many cases.

Additionally, this PR switches to a unified memory model on CPU. Previously, CPU was treated like hipSYCL's other targets (GPUs), i.e it was implicitly assumed that it has its own dedicated memory and requires data transfers between a host memory region and device memory regions. These unnecessary copies are now eliminated.

Notable changes in the code include:
* `nd_item`, `item` etc now explicitly store the iteration space information (ids and sizes) as member variables instead of querying them ondemand from the HIP builtins. This is necessary, because on the CPU we now have work items represented as different iterations of a loop, so we need to be able to change ids in each iteration. On GPU, the `HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO` macro is enabled by default which restores the "old" behavior of using the HIP builtins instead of member variables. Using this macro is only allowed on GPU, since it is incompatible with the new CPU execution model. Benchmarking is needed to test if there are any performance penalties to the new approach on GPU at all (e.g. register pressure) -- if not we could just drop support for the old approach.
* Custom OpenMP kernel execution/dispatch functions in `handler.hpp`. To separate those from the HIP ones, they are now in two different namespaces `sycl::detail::dispatch::device` and `sycl::detail::dispatch::host`. This also made some changes necessary to the clang plugin/source transformation where the code tries to identify the dispatch function by their name, which now has changed.
* When reworking the `group` and `h_item` classes, I've also taken this opportunity to lay the foundation for the support of flexible work group ranges. The corresponding parallel for functions are not yet enabled, but most of the work should now already be done.
* For helper functions related to `id<>`, the `detail::id` namespace has been introduced. This has required all uses of `id<>` inside `detail` to be changed to `sycl::id<>`, in analogy to what is already done for `range<>`.

Caveats/Regressions:
* ndrange parallel for does still use the old execution model, due to the barriers that can occur here. The plan is to also transition this to the new model in a subsequent PR. This would require code in the clang plugin's IR pass that splits the inner loop over the work items whenever a `barrier()` is called.
* ~~dynamic local memory inside hierarchical parallel for does not work correctly. This is because local memory is managed by hipCPU which still assumes that parallelization is only over the work items, i.e. there can only be once work group active at any given time. We need to change the local memory buffer to one large buffer, segmented into the local memory portions of each individual work group. This will be addressed in a subsequent commit.~~ This regression should be fixed as of 17560f2

---
This PR changes code related to the heart of kernel execution, and impacts any backend. We should therefore test this with as much code as possible before merging.

Unit tests have been run and passed for (the code should not differentiate between ROCm and CUDA backends, only between CPU and GPU):

- [x] `syclcc-clang` + CPU
- [x] `syclcc-clang` + GPU + `HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO`
- [x] `syclcc-clang` + GPU without `HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO`
- [ ] `syclcc` + CPU
- [ ] `syclcc` + GPU + `HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO`
- [ ] `syclcc` + GPU without `HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO`

(note that the CPU backend is not expected to pass the explicit copy tests since hipCPU does not implement the multidimensional variants of `hipMemcpyAsync`)