### PR TITLE
Fix genfloat binary math operations and add unit testing for them

### DIFF
--- a/include/CL/sycl/vec.hpp
+++ b/include/CL/sycl/vec.hpp
@@ -1546,7 +1546,7 @@ vec<T,N> binary_vector_operation(const vec<T,N>& a,
                                  const vec<T,N>& b,
                                  Function f)
 {
-  return a._impl.binary_operation(f, b);
+  return vec<T,N>(a._impl.binary_operation(f, b._impl));
 }
 
 template<class T, int N, class Function>


### PR DESCRIPTION
Fixes an oversight in binary operators that renders them unusable, and adds unit tests to hopefully prevent regressions in the future.

A lot more math unit tests would be needed for full coverage -- this fully covers the implemented binary operations on all types classified as `genfloat`.