### PR TITLE
Use unified memory on host

### DIFF
--- a/doc/macros.md
+++ b/doc/macros.md
@@ -10,6 +10,7 @@ Most of these are managed by `detail/backend/backend.hpp`.
 * `__HIPSYCL_DEVICE__` - defined if generating code for GPU
 * `SYCL_DEVICE_ONLY` - defined if generating code for GPU
 * `HIPSYCL_CLANG` - defined by `syclcc-clang` when compiling with the clang plugin
+* `HIPSYCL_SVM_SUPPORTED` - defined when the backend supports unified memory
 
 ## Mainly for hipSYCL developers
 * `__HIPSYCL_TRANSFORM__` defined by legacy `syclcc` during the source-to-source transformation step
@@ -19,3 +20,4 @@ Most of these are managed by `detail/backend/backend.hpp`.
 
 # Configuration macros
 * `HIPSYCL_EXT_FP_ATOMICS` - define before including `sycl.hpp` to enable the hipSYCL extension to allow atomic operations on floating point types. Since this is not in the spec, this may break portability. Additionally, not all hipSYCL backends may support the same set of FP atomics. It is the user's responsibility to ensure that the code remains portable and to implement fallbacks for platforms that don't support this.
+* `HIPSYCL_CPU_EMULATE_SEPARATE_MEMORY` - define during compilation of hipSYCL and SYCL programs to force the CPU backend to consider host and device memory as separate memory regions that require data transfers in between. This can be useful for debugging since it recreates what happens when targeting GPUs.

--- a/include/CL/sycl/backend/backend.hpp
+++ b/include/CL/sycl/backend/backend.hpp
@@ -89,6 +89,10 @@
  #define __hipsycl_launch_kernel hipLaunchKernelGGL
 #endif
 
+#if defined(HIPSYCL_PLATFORM_CUDA) || defined(HIPSYCL_PLATFORM_CPU)
+  #define HIPSYCL_SVM_SUPPORTED
+#endif
+
 namespace cl {
 namespace sycl {
 namespace detail {

--- a/include/CL/sycl/buffer.hpp
+++ b/include/CL/sycl/buffer.hpp
@@ -347,7 +347,7 @@ private:
 #if !defined(HIPSYCL_CPU_EMULATE_SEPARATE_MEMORY) && defined(HIPSYCL_PLATFORM_CPU)
     // force svm allocation
     device_mode = detail::device_alloc_mode::svm;
-    host_mode = detail::device_host_mode::svm;
+    host_mode = detail::host_alloc_mode::svm;
 #endif
     
     _buffer = detail::buffer_ptr{

--- a/include/CL/sycl/buffer.hpp
+++ b/include/CL/sycl/buffer.hpp
@@ -344,6 +344,12 @@ private:
                      detail::host_alloc_mode host_mode,
                      const range<dimensions>& range)
   {
+#if !defined(HIPSYCL_CPU_EMULATE_SEPARATE_MEMORY) && defined(HIPSYCL_PLATFORM_CPU)
+    // force svm allocation
+    device_mode = detail::device_alloc_mode::svm;
+    host_mode = detail::device_host_mode::svm;
+#endif
+    
     _buffer = detail::buffer_ptr{
       new detail::buffer_impl{
         sizeof(T) * range.size(), device_mode, host_mode
@@ -355,10 +361,17 @@ private:
   void create_buffer(T* host_memory,
                      const range<dimensions>& range)
   {
+#if !defined(HIPSYCL_CPU_EMULATE_SEPARATE_MEMORY) && defined(HIPSYCL_PLATFORM_CPU)
+    bool force_svm = true;
+#else
+    bool force_svm = false;
+#endif
+      
     _buffer = detail::buffer_ptr{
       new detail::buffer_impl{
         sizeof(T) * range.size(),
-        reinterpret_cast<void*>(host_memory)
+        reinterpret_cast<void*>(host_memory),
+        force_svm
       }
     };
     _range = range;
@@ -381,6 +394,7 @@ private:
     if(this->has_property<hipsycl::property::buffer::try_pinned_memory>())
       host_mode = detail::host_alloc_mode::allow_pinned;
 
+    
     if(this->has_property<hipsycl::property::buffer::use_svm>())
     {
       device_mode = detail::device_alloc_mode::svm;

--- a/include/CL/sycl/detail/buffer.hpp
+++ b/include/CL/sycl/detail/buffer.hpp
@@ -127,7 +127,8 @@ public:
               host_alloc_mode host_alloc_mode = host_alloc_mode::regular);
 
   buffer_impl(size_t buffer_size,
-              void* host_ptr);
+              void* host_ptr,
+              bool is_svm_ptr = false);
 
   ~buffer_impl();
 


### PR DESCRIPTION
This changes the way memory is treated on host by using a unified memory model on CPU, removing unnecessary data transfers between host and "device" buffers.