### PR TITLE
Add "Common Functions" as per spec, including unit tests

### DIFF
--- a/include/CL/sycl.hpp
+++ b/include/CL/sycl.hpp
@@ -52,6 +52,7 @@
 #include "sycl/vec.hpp"
 #include "sycl/builtin.hpp"
 #include "sycl/math.hpp"
+#include "sycl/common_functions.hpp"
 #include "sycl/atomic.hpp"
 #include "sycl/program.hpp"
 #include "sycl/kernel.hpp"

--- a/include/CL/sycl/builtin.hpp
+++ b/include/CL/sycl/builtin.hpp
@@ -70,7 +70,7 @@ inline T __placeholder_function(T, T, T) {return T();}
 #define HIPSYCL_DEFINE_GENINTEGERN_FUNCTION(name, func) \
   template<class int_type, int N, \
            HIPSYCL_ENABLE_IF_INTEGRAL(int_type)> \
-  __device__ \
+  HIPSYCL_KERNEL_TARGET \
   inline vec<int_type, N> name(const vec<int_type, N>& a) {\
     vec<int_type,N> result = a; \
     detail::transform_vector(result, \
@@ -82,7 +82,7 @@ inline T __placeholder_function(T, T, T) {return T();}
 #define HIPSYCL_DEFINE_GENINTEGERN_BINARY_FUNCTION(name, func) \
   template<class int_type, int N, \
            HIPSYCL_ENABLE_IF_INTEGRAL(int_type)> \
-  __device__ \
+  HIPSYCL_KERNEL_TARGET \
   inline vec<int_type, N> name(const vec<int_type, N>& a, \
                                  const vec<int_type, N>& b) {\
     return detail::binary_vector_operation(a,b,\
@@ -90,12 +90,12 @@ inline T __placeholder_function(T, T, T) {return T();}
   }
 
 #define HIPSYCL_DEFINE_BUILTIN(name, func) \
-  template<class T> \
-  __device__ inline T name(T x) {return HIPSYCL_STD_FUNCTION(func)(x);}
+  template<class T, HIPSYCL_ENABLE_IF_INTEGRAL(T)> \
+  HIPSYCL_KERNEL_TARGET inline T name(T x) {return HIPSYCL_STD_FUNCTION(func)(x);}
 
 #define HIPSYCL_DEFINE_BINARY_BUILTIN(name, func) \
-  template<class T> \
-  __device__ inline T name(T x,T y) {return HIPSYCL_STD_FUNCTION(func)(x,y);}
+  template<class T, HIPSYCL_ENABLE_IF_INTEGRAL(T)> \
+  HIPSYCL_KERNEL_TARGET inline T name(T x,T y) {return HIPSYCL_STD_FUNCTION(func)(x,y);}
 
 #ifdef __HIPCPU__
  #define HIPSYCL_DEFINE_GENINTEGER_STD_FUNCTION(func) \

--- a/include/CL/sycl/common_functions.hpp
+++ b/include/CL/sycl/common_functions.hpp
@@ -1,0 +1,140 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2019 hipSYCL contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef HIPSYCL_COMMON_FUNCTIONS_HPP
+#define HIPSYCL_COMMON_FUNCTIONS_HPP
+
+#include <type_traits>
+
+#include "vec.hpp"
+#include "math.hpp"
+
+namespace cl {
+namespace sycl {
+
+namespace detail {
+  template<class T>
+  constexpr T pi = T(3.1415926535897932385L);
+}
+
+template<typename T>
+inline auto clamp(T x, T minval, T maxval) {
+  return fmin(fmax(x, minval), maxval);
+}
+template<typename T, typename D, std::enable_if_t<!std::is_same<D,T>::value, int> = 0>
+inline auto clamp(T x, D minval, D maxval) {
+  return fmin(fmax(x, T{minval}), T{maxval});
+}
+
+template<typename T, std::enable_if_t<std::is_floating_point<T>::value, int> = 0>
+inline T degrees(T radians) {
+  return static_cast<T>(180)/detail::pi<T> * radians;
+}
+template<typename T, std::enable_if_t<!std::is_floating_point<T>::value, int> = 0>
+inline T degrees(T radians) {
+  return static_cast<typename T::element_type>(180)/detail::pi<typename T::element_type> * radians;
+}
+
+template<typename T>
+inline auto max(T x, T y) {
+  return fmax(x, y);
+}
+template<typename T, typename D, std::enable_if_t<!std::is_same<D,T>::value, int> = 0>
+inline auto max(T x, D y) {
+  return fmax(x, T{y});
+}
+
+template<typename T>
+inline auto min(T x, T y) {
+  return fmin(x, y);
+}
+template<typename T, typename D, std::enable_if_t<!std::is_same<D,T>::value, int> = 0>
+inline auto min(T x, D y) {
+  return fmin(x, T{y});
+}
+
+template<typename T, typename D>
+inline auto mix(T x, T y, D a) {
+  return x + (y - x) * a;
+}
+
+template<typename T, std::enable_if_t<std::is_floating_point<T>::value, int> = 0>
+inline T radians(T deg) {
+  return detail::pi<T>/static_cast<T>(180) * deg;
+}
+template<typename T, std::enable_if_t<!std::is_floating_point<T>::value, int> = 0>
+inline T radians(T deg) {
+  return detail::pi<typename T::element_type>/static_cast<typename T::element_type>(180) * deg;
+}
+
+template<typename T, std::enable_if_t<std::is_floating_point<T>::value, int> = 0>
+inline T step(T edge, T x) {
+  return x < edge ? 0.0 : 1.0;
+}
+template<typename T, typename E = typename T::element_type, std::enable_if_t<!std::is_floating_point<T>::value, int> = 0>
+inline T step(T edge, T x) {
+  return detail::binary_vector_operation(edge, x, [](E _e, E _x) { return step(_e, _x); });
+}
+template<typename D, typename T, typename E = typename T::element_type,
+  std::enable_if_t<std::is_floating_point<D>::value && !std::is_floating_point<T>::value, int> = 0>
+inline T step(D edge, T x) {
+  detail::transform_vector(x, [edge](E _x) { return step(edge, _x); });
+  return x;
+}
+
+template<typename T, std::enable_if_t<std::is_floating_point<T>::value, int> = 0>
+inline T smoothstep(T edge0, T edge1, T x) {
+  T t = clamp((x - edge0) / (edge1 - edge0), T{0}, T{1});
+  return t * t * (T{3} - T{2} * t);
+}
+template<typename T, typename E = typename T::element_type>
+inline T smoothstep(T edge0, T edge1, T x) {
+  T t = clamp((x - edge0) / (edge1 - edge0), E{0}, E{1});
+  return t * t * (E{3} - E{2} * t);
+}
+template<typename D, typename T, std::enable_if_t<!std::is_same<D,T>::value, int> = 0>
+inline T smoothstep(D edge0, D edge1, T x) {
+  return smoothstep(T{edge0}, T{edge1}, x);
+}
+
+template<typename T, std::enable_if_t<std::is_floating_point<T>::value, int> = 0>
+inline T sign(T x) {
+  if(x > T{0}) return T{1};
+  if(x < T{0}) return T{-1};
+  if(std::isnan(x)) return 0;
+  return x;
+}
+template<typename T, typename E = typename T::element_type, std::enable_if_t<!std::is_floating_point<T>::value, int> = 0>
+inline T sign(T x) {
+  detail::transform_vector(x, [](E e) { return sign(e); });
+  return x;
+}
+
+} // namespace sycl
+} // namespace cl
+
+#endif // HIPSYCL_COMMON_FUNCTIONS_HPP

--- a/include/CL/sycl/common_functions.hpp
+++ b/include/CL/sycl/common_functions.hpp
@@ -36,92 +36,105 @@
 namespace cl {
 namespace sycl {
 
-namespace detail {
-  template<class T>
-  constexpr T pi = T(3.1415926535897932385L);
-}
-
 template<typename T>
+HIPSYCL_KERNEL_TARGET
 inline auto clamp(T x, T minval, T maxval) {
   return fmin(fmax(x, minval), maxval);
 }
 template<typename T, typename D, std::enable_if_t<!std::is_same<D,T>::value, int> = 0>
+HIPSYCL_KERNEL_TARGET
 inline auto clamp(T x, D minval, D maxval) {
   return fmin(fmax(x, T{minval}), T{maxval});
 }
 
-template<typename T, std::enable_if_t<std::is_floating_point<T>::value, int> = 0>
+template<typename T, HIPSYCL_ENABLE_IF_FLOATING_POINT(T)>
+HIPSYCL_KERNEL_TARGET
 inline T degrees(T radians) {
-  return static_cast<T>(180)/detail::pi<T> * radians;
+  return T{180}/T{M_PI} * radians;
 }
-template<typename T, std::enable_if_t<!std::is_floating_point<T>::value, int> = 0>
+template<typename T, typename E = typename T::element_type, std::enable_if_t<!std::is_floating_point<T>::value, int> = 0>
+HIPSYCL_KERNEL_TARGET
 inline T degrees(T radians) {
-  return static_cast<typename T::element_type>(180)/detail::pi<typename T::element_type> * radians;
+  return E{180}/E{M_PI} * radians;
 }
 
 template<typename T>
+HIPSYCL_KERNEL_TARGET
 inline auto max(T x, T y) {
   return fmax(x, y);
 }
 template<typename T, typename D, std::enable_if_t<!std::is_same<D,T>::value, int> = 0>
+HIPSYCL_KERNEL_TARGET
 inline auto max(T x, D y) {
   return fmax(x, T{y});
 }
 
 template<typename T>
+HIPSYCL_KERNEL_TARGET
 inline auto min(T x, T y) {
   return fmin(x, y);
 }
 template<typename T, typename D, std::enable_if_t<!std::is_same<D,T>::value, int> = 0>
+HIPSYCL_KERNEL_TARGET
 inline auto min(T x, D y) {
   return fmin(x, T{y});
 }
 
 template<typename T, typename D>
+HIPSYCL_KERNEL_TARGET
 inline auto mix(T x, T y, D a) {
   return x + (y - x) * a;
 }
 
-template<typename T, std::enable_if_t<std::is_floating_point<T>::value, int> = 0>
+template<typename T, HIPSYCL_ENABLE_IF_FLOATING_POINT(T)>
+HIPSYCL_KERNEL_TARGET
 inline T radians(T deg) {
-  return detail::pi<T>/static_cast<T>(180) * deg;
+  return T{M_PI}/T{180} * deg;
 }
-template<typename T, std::enable_if_t<!std::is_floating_point<T>::value, int> = 0>
+template<typename T, typename E = typename T::element_type, std::enable_if_t<!std::is_floating_point<T>::value, int> = 0>
+HIPSYCL_KERNEL_TARGET
 inline T radians(T deg) {
-  return detail::pi<typename T::element_type>/static_cast<typename T::element_type>(180) * deg;
+  return E{M_PI}/E{180} * deg;
 }
 
-template<typename T, std::enable_if_t<std::is_floating_point<T>::value, int> = 0>
+template<typename T, HIPSYCL_ENABLE_IF_FLOATING_POINT(T)>
+HIPSYCL_KERNEL_TARGET
 inline T step(T edge, T x) {
   return x < edge ? 0.0 : 1.0;
 }
 template<typename T, typename E = typename T::element_type, std::enable_if_t<!std::is_floating_point<T>::value, int> = 0>
+HIPSYCL_KERNEL_TARGET
 inline T step(T edge, T x) {
   return detail::binary_vector_operation(edge, x, [](E _e, E _x) { return step(_e, _x); });
 }
 template<typename D, typename T, typename E = typename T::element_type,
   std::enable_if_t<std::is_floating_point<D>::value && !std::is_floating_point<T>::value, int> = 0>
+HIPSYCL_KERNEL_TARGET
 inline T step(D edge, T x) {
   detail::transform_vector(x, [edge](E _x) { return step(edge, _x); });
   return x;
 }
 
-template<typename T, std::enable_if_t<std::is_floating_point<T>::value, int> = 0>
+template<typename T, HIPSYCL_ENABLE_IF_FLOATING_POINT(T)>
+HIPSYCL_KERNEL_TARGET
 inline T smoothstep(T edge0, T edge1, T x) {
   T t = clamp((x - edge0) / (edge1 - edge0), T{0}, T{1});
   return t * t * (T{3} - T{2} * t);
 }
 template<typename T, typename E = typename T::element_type>
+HIPSYCL_KERNEL_TARGET
 inline T smoothstep(T edge0, T edge1, T x) {
   T t = clamp((x - edge0) / (edge1 - edge0), E{0}, E{1});
   return t * t * (E{3} - E{2} * t);
 }
 template<typename D, typename T, std::enable_if_t<!std::is_same<D,T>::value, int> = 0>
+HIPSYCL_KERNEL_TARGET
 inline T smoothstep(D edge0, D edge1, T x) {
   return smoothstep(T{edge0}, T{edge1}, x);
 }
 
-template<typename T, std::enable_if_t<std::is_floating_point<T>::value, int> = 0>
+template<typename T, HIPSYCL_ENABLE_IF_FLOATING_POINT(T)>
+HIPSYCL_KERNEL_TARGET
 inline T sign(T x) {
   if(x > T{0}) return T{1};
   if(x < T{0}) return T{-1};
@@ -129,6 +142,7 @@ inline T sign(T x) {
   return x;
 }
 template<typename T, typename E = typename T::element_type, std::enable_if_t<!std::is_floating_point<T>::value, int> = 0>
+HIPSYCL_KERNEL_TARGET
 inline T sign(T x) {
   detail::transform_vector(x, [](E e) { return sign(e); });
   return x;


### PR DESCRIPTION
Also refactors testing and extends test coverage to vec8 and vec16.

Note that the functions are mostly implemented in a straightforward fashion. There might be more efficient mappings of some of them to some backends (e.g. CUDA), but I think for now it's most important to be standard compliant.