### PR TITLE
Silence deprecation warnings in hip which occur for newer CUDA versions

### DIFF
--- a/include/CL/sycl/backend/backend.hpp
+++ b/include/CL/sycl/backend/backend.hpp
@@ -45,7 +45,11 @@
 // for GPU, and hipCPU if compiling for CPU
  #if defined(__CUDACC__)
   #define HIPSYCL_PLATFORM_CUDA
+  // Silence deprecation warnings in hip which occur for newer CUDA versions
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wdeprecated-declarations"
   #include <hip/hip_runtime.h>
+  #pragma clang diagnostic pop
  #elif defined(__HIP__) || defined(__HCC__)
   #define HIPSYCL_PLATFORM_HCC
   #include <hip/hip_runtime.h>


### PR DESCRIPTION
This is just a small change to silence deprecation warnings in the hip runtime (which is a big quality of life improvement since it allows you to build hipSYCL programs targeting newer CUDA platforms without getting a lot of warnings in platform code).

This should of course be removed if/when the hip runtime is updated.