### PR TITLE
Rework accessor tracking, remove accessor_tracker

### DIFF
--- a/include/CL/sycl/detail/mobile_shared_ptr.hpp
+++ b/include/CL/sycl/detail/mobile_shared_ptr.hpp
@@ -57,6 +57,7 @@ public:
   {}
 #endif
 
+  HIPSYCL_UNIVERSAL_TARGET
   const T* get() const
   { 
 #ifdef SYCL_DEVICE_ONLY
@@ -67,6 +68,7 @@ public:
 #endif
   }
 
+  HIPSYCL_UNIVERSAL_TARGET
   T* get()
   { 
 #ifdef SYCL_DEVICE_ONLY

--- a/include/CL/sycl/detail/mobile_shared_ptr.hpp
+++ b/include/CL/sycl/detail/mobile_shared_ptr.hpp
@@ -1,0 +1,101 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2019 Aksel Alpay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef HIPSYCL_MOBILE_SHARED_PTR_HPP
+#define HIPSYCL_MOBILE_SHARED_PTR_HPP
+
+#include "../backend/backend.hpp"
+#include "../types.hpp"
+
+namespace cl {
+namespace sycl {
+namespace detail {
+
+/// A regular std::shared_ptr cannot be captured in kernels,
+/// since it will in general depend on code that is not available
+/// on device (C++ runtime, exceptions, CPU locks etc)
+/// This implements a shared_ptr that can be captured
+/// in device kernels. On CPU, it behaves like a regular shared_ptr.
+/// While the usual shared_ptr functionality
+/// regarding memory management is not supported on device,
+/// and the managed memory content is not available on device,
+/// it is guaranteed that the size of the object on host and device
+/// are equal, such that it can be used as a kernel argument without
+/// size mismatches.
+template<class T>
+class mobile_shared_ptr
+{
+public:
+  // Not available on device
+#ifndef SYCL_DEVICE_ONLY
+  mobile_shared_ptr(shared_ptr_class<T> ptr)
+  : _ptr{ptr}
+  {}
+#endif
+
+  const T* get() const
+  { 
+#ifdef SYCL_DEVICE_ONLY
+    // Use sizeof(_buff) to make sure it doesn't get optimized away
+    return reinterpret_cast<T*>(sizeof(_buff));
+#else
+    return _ptr.get(); 
+#endif
+  }
+
+  T* get()
+  { 
+#ifdef SYCL_DEVICE_ONLY
+    // Use sizeof(_buff) to make sure it doesn't get optimized away
+    return reinterpret_cast<T*>(sizeof(_buff));
+#else
+    return _ptr.get(); 
+#endif
+  }
+
+  // We cannot make this function available on device, since
+  // it would pull shared_ptr_class<T> into device code.
+#ifndef SYCL_DEVICE_ONLY
+  shared_ptr_class<T> get_shared_ptr() const
+  {
+    return _ptr;
+  }
+#endif
+
+private:
+#ifdef SYCL_DEVICE_ONLY
+  char _buff[sizeof(shared_ptr_class<T>)];
+#else
+  shared_ptr_class<T> _ptr;
+#endif
+};
+
+}
+}
+}
+
+#endif

--- a/include/CL/sycl/detail/runtime.hpp
+++ b/include/CL/sycl/detail/runtime.hpp
@@ -29,80 +29,13 @@
 #ifndef HIPSYCL_RUNTIME_HPP
 #define HIPSYCL_RUNTIME_HPP
 
-#include <unordered_map>
-#include <cassert>
-
 #include "task_graph.hpp"
-#include "buffer.hpp"
-#include "../access.hpp"
-#include "../types.hpp"
 
+#include <iostream>
 namespace cl {
 namespace sycl {
 namespace detail {
 
-class accessor_base;
-
-class accessor_tracker
-{
-public:
-
-  void new_accessor(
-      const accessor_base* accessor_ptr,
-      buffer_ptr buff)
-  {
-    std::lock_guard<mutex_class> lock{_lock};
-
-    const void* object_ptr = reinterpret_cast<const void*>(accessor_ptr);
-    assert(_buffer_map.find(object_ptr) ==
-           _buffer_map.end());
-
-    _buffer_map[object_ptr] = buff;
-  }
-
-  void set_accessor_buffer(
-      const accessor_base* accessor_ptr,
-      buffer_ptr buff)
-  {
-    std::lock_guard<mutex_class> lock{_lock};
-
-    const void* object_ptr = reinterpret_cast<const void*>(accessor_ptr);
-    assert(_buffer_map.find(object_ptr) !=
-           _buffer_map.end());
-
-    _buffer_map[object_ptr] = buff;
-  }
-
-  void release_accessor(
-      const accessor_base* accessor_ptr)
-  {
-    std::lock_guard<mutex_class> lock{_lock};
-
-    const void* object_ptr = reinterpret_cast<const void*>(accessor_ptr);
-    assert(_buffer_map.find(object_ptr) !=
-           _buffer_map.end());
-
-    _buffer_map.erase(object_ptr);
-  }
-
-  buffer_ptr find_accessor(
-      const accessor_base* accessor_ptr) const
-  {
-    std::lock_guard<mutex_class> lock{_lock};
-
-    const void* object_ptr = reinterpret_cast<const void*>(accessor_ptr);
-    auto it = _buffer_map.find(object_ptr);
-
-    if(it == _buffer_map.end())
-      return nullptr;
-
-    return it->second;
-  }
-
-private:
-  mutable mutex_class _lock;
-  std::unordered_map<const void*, buffer_ptr> _buffer_map;
-};
 
 class runtime
 {
@@ -114,18 +47,10 @@ public:
   const task_graph& get_task_graph() const
   { return _task_graph; }
 
-  accessor_tracker&
-  get_accessor_tracker()
-  { return _accessor_tracker; }
-
-  const accessor_tracker&
-  get_accessor_tracker() const
-  { return _accessor_tracker; }
-
 private:
   task_graph _task_graph;
-  accessor_tracker _accessor_tracker;
 };
+
 
 }
 }

--- a/src/libhipSYCL/accessor.cpp
+++ b/src/libhipSYCL/accessor.cpp
@@ -88,7 +88,7 @@ void* obtain_device_access(buffer_ptr buff,
                                          cgh.get_stream(),
                                          cgh.get_stream()->get_error_handler());
 
-    cgh._detail_add_access(buff, access_mode, task_graph_node);
+    cgh.add_access(buff, access_mode, task_graph_node);
   }
   else
 #endif
@@ -101,12 +101,16 @@ void* obtain_device_access(buffer_ptr buff,
                                             cgh.get_stream(),
                                             cgh.get_stream()->get_error_handler());
 
-    cgh._detail_add_access(buff, access_mode, task_graph_node);
+    cgh.add_access(buff, access_mode, task_graph_node);
 
   }
   return access_ptr;
 }
 
+accessor_id request_accessor_id(buffer_ptr buff, sycl::handler& cgh)
+{
+  return cgh.request_accessor_id(buff);
+}
 
 }
 }


### PR DESCRIPTION
This reworks how accessor tracking works in hipSYCL. It removes the existing `accessor_tracker` entirely, and hence gets rid of the mutexes which can introduce unwanted synchronization and hence slow down things on CPU for small kernels (see [here](https://pbs.twimg.com/media/EBb_1oyWwAABSaH?format=jpg&name=4096x4096) for benchmarks).

## Background: Why do we need accessor tracking?
We need to be able to get for each accessor the corresponding `buffer_ptr` in order to register dependencies for the command group and initiate necessary data transfers. When a regular device accessor is created inside a command group, we are given the `buffer` as argument and can directly execute the necessary operations on that object.
For placeholders and explicit copy functions, things are more complicated as we need to execute buffer operations after the accessor has been created. Consequently, we need to store the associated `buffer_ptr` somewhere, i.e. we need to track the buffers associated with the accessors.

At the same time, the following constraints must be met:
* When targeting GPUs, accessors will be moved to device, so we cannot store anything inside that is not available on device (a `buffer_ptr` is a `shared_ptr`, which is unavailable on GPU)
* Accessors may be copied around, so we cannot just use a raw pointer since the underlying buffer object may go out of scope (especially placeholders are dangerous since they can exist indefinitely outside of the command group).

## How is this solved currently?
Currently, we have a globally available object - the `accessor_tracker` - as part of the hipSYCL runtime. The `accessor_tracker` maintains a map that associates the `this` pointers of the living accessors with the corresponding `buffer_ptr`.  On the host, whenever accessors are copied/created/moved they register/unregister themselves at the `accessor_tracker`. Since this can happen in a multithreaded context (which is already the case when executing a kernel on CPU, since OpenMP has to copy the accessors to all participating threads), `accessor_tracker` must be mutex-protected.
This can significantly increase kernel launch latency on CPU.

## What does this PR change?
The new approach proposed here rests on the observation, that with the exception of host accessors and placeholder accessors, all accessors are created with the command group handler as argument. These device accessors are therefore local to the command group and cannot escape it.

### Non-placeholder and non-host accessors.
This PR moves the accessor tracking for device accessors to the command group handler. The command group handler associates an accessor id with the `buffer_ptr`. Only the id (an `unsigned short`) is stored inside the accessors. Copying accessors on CPU is now efficient since it just requires copying an integer value instead of modifying a mutex-protected data structure in the `accessor_tracker`.

### Placeholder and host accessors
Placeholder and host accessors now store the `buffer_ptr` themselves. However, since the `buffer_ptr` cannot be migrated to device (which is required for placeholders), the new class  `mobile_shared_ptr` is used instead. This is a simple wrapper object that stores a regular `shared_ptr` on CPU. On GPU, it instead stores a padding of the same size as a `shared_ptr`. This is necessary to guarantee that the accessor has the same size on host and device. If this were not the case, kernel arguments on the caller's side (host) would have a different size than what the callee's side (device) expects, which would inevitably lead to massive trouble.



