### PR TITLE
clang plugin: Disable function pruning to un-break standard math functions in debug builds

### DIFF
--- a/src/hipsycl_clang_plugin/IR.hpp
+++ b/src/hipsycl_clang_plugin/IR.hpp
@@ -86,7 +86,11 @@ struct FunctionPruningIRPass : public llvm::ModulePass
       }
     }
 
-    pruneUnusedFunctions(M);
+    // Disable function pruning as it breaks standard math functions such as
+    // fmin, which are distributed over vector types using a function pointer.
+    // TODO: If no other issues come up, we should be able to remove function
+    // pruning for good.
+    // pruneUnusedFunctions(M);
     pruneUnusedGlobals(M);
 
     return true;


### PR DESCRIPTION
Currently, a simple program such as this one

```c++
int main() {
  namespace s = cl::sycl;
  s::queue queue;

  queue.submit([](s::handler& cgh) {
    cgh.parallel_for<class MyKernel>(s::range<1>(10), [](s::item<1> item) {
      s::float2 f = s::fmin(s::float2(1.23f, 1.32f), s::float2(2.42f, 0.32f));
      printf("%f %f\n", f.x(), f.y());
    });
  });

  queue.wait();
}
```
will throw a CUDA error 76 **when doing a non-optimized build**. Error 76 is a `cudaErrorInvalidPc`, which happens because CUDA is trying to access the function pointer to `std::fmin` that is to be applied to all elements of the two vectors. However, the IR pass prunes `std::fmin` because it's call graph doesn't understand the indirection. For optimized builds this presumably doesn't happen due to inlining.

This PR simply disables the IR function pruning pass. This shouldn't be a problem since as of #76 the pruning pass is somewhat superfluous anyways. I suggest unless we run into any other problems with this in the near future, we should remove it for good.