### PR TITLE
Update documentation and build system for ROCm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,29 +31,45 @@ endif()
 if(NOT LLVM_FOUND)
   message(SEND_ERROR "hipSYCL requires LLVM 8 or newer.")
 endif()
+message(STATUS "Building hipSYCL against LLVM configured from ${LLVM_DIR}")
 #find_package(Clang REQUIRED)
 
-# Make sure either hcc or nvcc can be found
+# Check for CUDA/ROCm and clang
 find_package(CUDA QUIET)
-find_program(HCC_COMPILER NAMES hcc)
-find_program(CLANG_EXECUTABLE_PATH NAMES clang++-10 clang++-10.0 clang++-9 clang++-9.0 clang++-8 clang++-8.0 clang++ CACHE STRING)
-if(CLANG_EXECUTABLE_PATH MATCHES "-NOTFOUND")
-  message(SEND_ERROR "Could not find clang executable in PATH")
-endif()
+# We currently search for hipcc to check for ROCm installation
+find_program(HIPCC_COMPILER NAMES hipcc HINTS ${ROCM_PATH})
+set(ROCM_PATH /opt/rocm CACHE PATH "Path to ROCm installation")
 
-# Even if we compile with clang, this tests
-# for the existence of CUDA which is also required for clang.
-# TODO: A better approach would be to find_package(CUDA) if
-# we build with clang.
-#if(NVCC_COMPILER MATCHES "-NOTFOUND")
-#  set(CUDA_FOUND false)
-#else()
-#  set(CUDA_FOUND true)
-#endif()
+find_program(CLANG_EXECUTABLE_PATH NAMES clang++-${LLVM_VERSION_MAJOR} clang++-${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR} clang++ CACHE STRING)
+if(CLANG_EXECUTABLE_PATH MATCHES "-NOTFOUND")
+  message(SEND_ERROR "Could not find clang executable")
+endif()
+message(STATUS "Selecting clang: ${CLANG_EXECUTABLE_PATH}")
+
+get_filename_component(LLVM_BIN_DIR ${CLANG_EXECUTABLE_PATH} DIRECTORY)
+get_filename_component(LLVM_PREFIX_DIR ${LLVM_BIN_DIR} DIRECTORY)
+# The path to the internal clang includes is currently required on ROCm
+# to let syclcc-clang fix a wrong order of system includes (clang's internal 
+# includes are not of high enough priority in the include path search order).
+# We identify this path as the one containing __clang_cuda_runtime_wrapper.h,
+# which is a clang-specific header file.
+find_path(CLANG_INCLUDE_PATH __clang_cuda_runtime_wrapper.h HINTS
+  ${LLVM_PREFIX_DIR}/include/clang/${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH}/include
+  ${LLVM_PREFIX_DIR}/include/clang/${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}/include
+  ${LLVM_PREFIX_DIR}/include/clang/${LLVM_VERSION_MAJOR}/include
+  ${LLVM_PREFIX_DIR}/lib/clang/${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH}/include
+  ${LLVM_PREFIX_DIR}/lib/clang/${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}/include
+  ${LLVM_PREFIX_DIR}/lib/clang/${LLVM_VERSION_MAJOR}/include
+  DOC "Path to internal clang headers. Typically, $LLVM_INSTALL_PREFIX/include/clang/<llvm-version>/include")
+
+if(NOT EXISTS ${CLANG_INCLUDE_PATH})
+    message(SEND_ERROR "clang include path ${CLANG_INCLUDE_PATH} does not exist. Please provide clang's internal include path manually.")
+endif()
+message(STATUS "Using clang include directory: ${CLANG_INCLUDE_PATH}")
 
 set(COMPILE_SOURCE_TRANSFORMATION_TOOLS false CACHE BOOL "Build optional source-to-source transformation tools for the legacy hipSYCL toolchain")
 
-if(HCC_COMPILER MATCHES "-NOTFOUND")
+if(HIPCC_COMPILER MATCHES "-NOTFOUND")
   set(ROCM_FOUND false)
 else()
   set(ROCM_FOUND true)
@@ -66,7 +82,15 @@ if(WITH_CUDA_BACKEND)
 endif()
 if(WITH_ROCM_BACKEND)
   if(NOT ROCM_FOUND)
-    message(SEND_ERROR "hcc was not found in PATH")
+    #  message(SEND_ERROR "hipcc was not found")
+  
+    # User has requested ROCm, but we could not find hipcc.
+    # this is not necessarily a reason to abort,
+    # since we only need libhip_hcc, the HIP includes,
+    # and the ROCm device headers. It could be that we
+    # are faced with a minimal/incomplete ROCm installation
+    # that could still be enough for us.
+    # Let's assume the user knows what he/she is doing.
   endif()
 endif()
 
@@ -108,9 +132,10 @@ set(SYCLCC_CONFIG_FILE "{
   \"default-cuda-path\" : \"${CUDA_TOOLKIT_ROOT_DIR}\",
   \"default-gpu-arch\" : \"${DEFAULT_GPU_ARCH}\",
   \"default-cpu-cxx\" : \"${CMAKE_CXX_COMPILER}\",
-  \"default-rocm-path\" : \"/opt/rocm/\",
+  \"default-rocm-path\" : \"${ROCM_PATH}\",
   \"default-use-bootstrap-mode\" : \"false\",
-  \"default-is-dryrun\" : \"false\"
+  \"default-is-dryrun\" : \"false\",
+  \"default-clang-include-path\" : \"${CLANG_INCLUDE_PATH}\"
 }
 ")
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ hipSYCL is still in an early stage of development. It can successfully execute m
 In order to successfully build and install hipSYCL, the following major requirements must be met:
 
 #### Hardware and OS
-* We support CPUs and NVIDIA CUDA GPUs and AMD GPUs that are [supported by ROCm](https://github.com/RadeonOpenCompute/ROCm#hardware-support)
+* We support CPUs, NVIDIA CUDA GPUs and AMD GPUs that are [supported by ROCm](https://github.com/RadeonOpenCompute/ROCm#hardware-support)
 * hipSYCL currently does not support other operating systems besides Linux due to a lack of maintainers for other platforms. While the AMD backend can only work on Linux since AMD doesn't support ROCm on other platforms, the CUDA and CPU backends should in principle be portable. If you are interested in porting and maintaining hipSYCL on other platforms, feel encouraged to do so and get in touch with us.
 
 #### Software dependencies
@@ -76,14 +76,20 @@ In order to successfully build and install hipSYCL, the following major requirem
 * *For the CUDA backend*: 
   * **CUDA >= 9.0** must be installed.
   * hipSYCL requires clang for CUDA compilation. clang usually produces CUDA programs with very competitive performance compared to nvcc. For more information on compiling CUDA with clang, see [here](http://llvm.org/docs/CompileCudaWithLLVM.html).
-  Our internal testing is conducted with CUDA 10 and clang 8. Note that CUDA 10.1 requires clang 9 or newer.
+  * Read more about [compatible clang and CUDA versions for the CUDA backend](doc/install-cuda.md).
 * *For the ROCm backend*: 
-  * **ROCm >= 2.0** must be installed. HIP-clang must be installed as described by AMD [here](https://github.com/ROCm-Developer-Tools/HIP/blob/master/INSTALL.md#hip-clang). Unfortunately, AMD does not yet provide binary packages, so you will have to compile the compiler stack from source. hipSYCL must be compiled against this clang/llvm distribution.
+  * **ROCm >= 2.0** must be installed. 
+  * hipSYCL requires clang for ROCm compilation. While AMD's clang forks can in principle be used, regular clang is usually easier to set up. Read more about [compatible clang versions for the ROCm backend](doc/install-rocm.md).
 * *For the CPU backend*: Any C++ compiler with **OpenMP** support should do. We test with clang 8, 9 and gcc 8.2.
 * python 3 (for the `syclcc` and `syclcc-clang` compiler wrappers)
 * `cmake`
 * hipSYCL also depends on HIP, but already comes bundled with a version of the HIP headers for the CUDA backend. The ROCm backend will use the HIP installation that is installed as part of ROCm.
 * the Boost C++ library (preprocessor, filesystem)
+
+If hipSYCL does not automatically configure the build for the desired clang/LLVM installation, the following cmake variables can be used to point hipSYCL to the right one:
+* `LLVM_DIR` must be pointed to your LLVM installation (specifically, the subdirectory containing the LLVM cmake files)
+* `CLANG_EXECUTABLE_PATH` must be pointed to the clang executable from this LLVM installation.
+* `CLANG_INCLUDE_PATH` must be pointed to the clang internal header directory. Typically, this is something like `$LLVM_INSTALL_PREFIX/include/clang/<llvm-version>/include`.
 
 ### Manual compilation
 
@@ -100,6 +106,8 @@ $ make install
 The default installation prefix is `/usr/local`. Change this to your liking.
 
 ### Packages
+** Note: hipSYCL packaging is currently being reworked - the following may or may not work. **
+
 For Arch Linux users, it is recommended to simply use the `PKGBUILD` provided in `install/archlinux`. A simple `makepkg` in this directory should be enough to build an Arch Linux package.
 
 ### Singularity container images

--- a/bin/syclcc-clang
+++ b/bin/syclcc-clang
@@ -150,6 +150,9 @@ class syclcc_config:
       'cpu-compiler': option("--hipsycl-cpu-cxx", "HIPSYCL_CPU_CXX", "default-cpu-cxx",
 """  The compiler that should be used when targeting only CPUs."""),
       
+      'clang-include-path' : option("--hipsycl-clang-include-path", "HIPSYCL_CLANG_INCLUDE_PATH", "default-clang-include-path",
+"""  The path to clang's internal include headers. Typically of the form $PREFIX/include/clang/<version>/include. Only required by ROCm."""),
+      
       'config-file' : option("--hipsycl-config-file", "HIPSYCL_CONFIG_FILE", "default-config-file",
 """  Select an alternative path for the config file containing the default hipSYCL settings.
     It is normally not necessary for the user to change this setting.""")
@@ -296,7 +299,7 @@ class syclcc_config:
     elif platform in pure_cpu_platform_synonyms:
       return hipsycl_platform.PURE_CPU
 
-    raise RuntimeError("Invalid hipSYCL platform: "+platform)
+    raise RuntimeError("Invalid hipSYCL platform: '{}'".format(platform))
 
   @property
   def target_arch(self):
@@ -319,10 +322,14 @@ class syclcc_config:
     return self._retrieve_option("cpu-compiler")
 
   @property
+  def clang_include_path(self):
+    return self._retrieve_option("clang-include-path")
+
+  @property
   def hipsycl_installation_path(self):
     syclcc_path = os.path.dirname(os.path.realpath(__file__))
     return os.path.join(syclcc_path, "..")
-    
+  
   @property
   def forwarded_compiler_arguments(self):
     return self._forwarded_args
@@ -337,6 +344,7 @@ class syclcc_config:
       return self._is_flag_set("is-dryrun")
     except OptionNotSet:
       return False
+  
 
   def contains_linking_stage(self):
     for arg in self.forwarded_compiler_arguments:
@@ -412,7 +420,12 @@ class clang_plugin_compiler:
         "--cuda-gpu-arch=" + config.target_arch,
         "--hip-device-lib-path=" + os.path.join(config.rocm_path, "lib"),
         "-I" + os.path.join(config.rocm_path, "include"),
-        "-isystem", self._get_rocm_clang_include_path(config.rocm_path)
+        # This here is necessary because some distributions of clang
+        # incorrectly have the gcc/system headers *before* clangs own
+        # include path. This causes "file not found" errors when the
+        # clang CUDA wrapper headers try to include the system headers
+        # with #include_next <...>
+        "-isystem", self._get_rocm_clang_include_path(config)
       ]
 
     self._common_compiler_args = ["-std=c++14"]
@@ -430,16 +443,8 @@ class clang_plugin_compiler:
         "-I"+os.path.join(config.hipsycl_installation_path, "contrib/HIP/include")
       ]
 
-  def _get_rocm_clang_include_path(self, rocm_path):
-    base_dir = os.path.join(rocm_path, "hcc/lib/clang")
-    subdirs = [subdir for subdir in os.listdir(base_dir)
-              if os.path.isdir(os.path.join(base_dir, subdir))]
-
-    if len(subdirs) == 0:
-      raise RuntimeError("Could not find internal ROCm clang headers")
-
-    # There is usually only one subdirectory
-    return os.path.join(base_dir, subdirs[0], "include")
+  def _get_rocm_clang_include_path(self, config):
+    return config.clang_include_path
 
   def run(self):
 
@@ -452,7 +457,6 @@ class clang_plugin_compiler:
       command += self._linker_args
     
     command += self._args
-    
     return run_or_print(command, self._is_dry_run)
     
     

--- a/doc/install-cuda.md
+++ b/doc/install-cuda.md
@@ -1,0 +1,9 @@
+# hipSYCL installation notes for CUDA
+Installing hipSYCL for CUDA is relatively straight forward. The following requirements must be met:
+* clang must be built without the `_DEBUG` macro defined. Compiling clang with `_DEBUG` is a configuration that hipSYCL does not support due to incorrect `assert()` statements inside clang that get triggered due to the - from clang's perspective - slightly unusual and unexpected way in which hipSYCL employs the HIP/CUDA toolchains. Regular clang release builds as they can be found in distributions usually meet this requirement.
+* clang must have been compiled with the NVPTX backend enabled (which is usually the case)
+* Note that clang 8 only supports CUDA 9.x.
+* Note that clang 9 supports CUDA 10. However, CUDA 10.1 is known to cause runtime crashes for CUDA code compiled with clang 9 in some cases. We therefore recommend CUDA 10.0.
+
+The following cmake variables may be relevant:
+* Use `CUDA_TOOLKIT_ROOT_DIR` to point hipSYCL to the CUDA root installation directory (e.g. `/usr/local/cuda`), if cmake doesn't find the right CUDA installation.

--- a/doc/install-rocm.md
+++ b/doc/install-rocm.md
@@ -1,0 +1,24 @@
+# hipSYCL installation notes for ROCm
+
+In general, hipSYCL on ROCm requires a clang installation that satisfies the following conditions:
+* clang must **not** be compiled with the `_DEBUG` macro enabled (otherwise, hipSYCL triggers incorrect `assert()` statements inside clang due to the, from clang's perpective, unusual way in which it employs the HIP/CUDA toolchain). Regular clang release builds as they can be found in distributions usually meet this requirement.
+* clang versions older than 8 are not supported
+* clang must have been built with the AMDGPU backend enabled (which is usually the case)
+* lld is also required.
+
+Additionally, please take note of the following:
+* **regular LLVM/clang distributions:** hipSYCL can run with regular clang/LLVM distributions, as long as you have matching ROCm device and runtime libraries installed. This is usually **the easiest way and therefore recommended.** The following combinations of mainline clang and ROCm are known to work:
+  * clang 10 with ROCm 2.6
+  * clang 9 with ROCm 2.6
+  * HIP support was introduced in clang 8, so anything older than clang 8 cannot work.
+  If you use a debian-based Linux distribution (e.g. Debian/Ubuntu), you can get binary packages for llvm/clang from [apt.llvm.org](http://apt.llvm.org). Note that currently the clang 9 packages seem to be packaged incorrectly, preventing correct detection of the installation by hipSYCL's cmake - you will have to use the nightly clang 10 snapshots.
+* **clang distributions from AMD:**
+  * In principle, clang forks from AMD like `aomp` releases can be used as well, however at least the aomp 0.7 binary packages are compiled with the `_DEBUG` macro enabled, which is unsupported as described above. Additionally, the way that aomp currently advertises its version causes cmake's version identification to discard it as incompatible (we specifically ask for clang/LLVM 8,9 or 10).
+
+Once you have a suitable clang installed, make sure to compile hipSYCL against this clang. 
+
+The following cmake variables may be relevant:
+* Use `ROCM_PATH` to point hipSYCL to ROCm, if you haven't installed it in /opt/rocm.
+
+
+


### PR DESCRIPTION
This addresses several issues, mostly targeted at polishing ROCm
support.
* New cmake variable `CLANG_INCLUDE_PATH` for the internal clang include
path (required for ROCm). This variable is put into the `syclcc-clang`
config file. `syclcc-clang` can then use this path to correct the
include path priority which tends to be incorrect on ROCm. By default,
cmake will assume
`$CLANG_EXECUTABLE_PATH/../include/clang/$LLVM_VERSION_MAJOR/include`
which works for mainline clang distributions. Fixes issue #93.
* The clang version that cmake looks for is now tied to the LLVM version
that was obtained from the `find_package(LLVM)` call.
* New cmake variable `ROCM_PATH` to make ROCm installation path
configurable
* cmake on ROCm does not look for `hcc` (which is both deprecated and
not relevant anymore for hipSYCL) anymore to detect ROCm, but instead it
looks for `hipcc`. While hipSYCL doesn't use `hipcc` directly, it needs
HIP which contains `hipcc`.
* Add clarification in documentation regarding compatible clang versions
for both CUDA and ROCm. On ROCm, recommended clang is now a recent *mainline*
clang since they seem to work well and are usually easier to install
than AMD clang forks.