### PR TITLE
Fix deprecated nd_item::get_local()

### DIFF
--- a/include/CL/sycl/nd_item.hpp
+++ b/include/CL/sycl/nd_item.hpp
@@ -92,14 +92,14 @@ struct nd_item
   HIPSYCL_KERNEL_TARGET
   id<dimensions> get_local() const
   {
-    return detail::get_local_id<dimensions>();
+    return this->get_local_id();
   }
 
   [[deprecated]] 
   HIPSYCL_KERNEL_TARGET
   size_t get_local(int dimension) const
   {
-    return detail::get_local_id(dimension);
+    return this->get_local_id(dimension);
   }
 
   HIPSYCL_KERNEL_TARGET


### PR DESCRIPTION
The deprecated `nd_item::get_local()` member function unconditionally calls `detail::get_local_id()`. This is problematic because `detail::get_local_id()` is a `__device__` function that accesses `hipBlockDim`. 
Since `nd_item::get_local()` is `__host__ __device__`, this causes clang to error due to an invalid call to a `__device__` function (remember that in hipSYCL, all SYCL code is initially parsed as host code).

This fixes this issue by pointing `nd_item::get_local()` to `nd_item::get_local_id()` which correctly never calls `detail::get_local_id()` when compiling for host.