### PR TITLE
Add initial automatic test infrastructure

### DIFF
--- a/auto-test/build.py
+++ b/auto-test/build.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+import os
+import os.path
+import sys
+import subprocess
+
+def get_from_environment_or_default(variable_name, default_value):
+  if variable_name in os.environ:
+    return os.environ[variable_name]
+  else:
+    return default_value
+  
+def ensure_directory_exists(dirname):
+  os.makedirs(dirname, exist_ok=True)
+  
+def are_runtime_tests_allowed(platform_name):
+  if "HIPSYCL_NO_RUNTIME_TESTING" in os.environ:
+    disabled_platforms = os.environ["HIPSYCL_NO_RUNTIME_TESTING"].lower().split(',')
+    if platform_name in disabled_platforms:
+      return False
+  return True
+  
+def raise_if_nonzero(command, environment={}):
+  returncode = subprocess.call(command, env=environment, shell=True)
+  if returncode != 0:
+    raise RuntimeError("Command {} returned exit code {}".format(command,returncode))
+
+if __name__ == '__main__':
+  # The path where built images will be stored.
+  build_path = os.path.join(os.getcwd(),"../../hipsycl-singularity-build")
+  cuda_gpu_arch = get_from_environment_or_default("CUDA_GPU_ARCH", "sm_52")
+  rocm_gpu_arch = get_from_environment_or_default("ROCM_GPU_ARCH", "gfx906")
+  singularity_executable = get_from_environment_or_default("SINGULARITY_PATH","/usr/bin/singularity")
+  # Path to the hipSYCL source code
+  source_path = ""
+  # Path where the final container image containing hipSYCL will be stored
+  image_path = ""
+  # Path where the base image will be stored. The base image contains
+  # the required components to build hipSYCL (e.g. ROCm, CUDA, clang/llvm).
+  # Storing the base image separately and building the hipSYCL image
+  # on top of it allows for faster builds of subsequent invocations
+  # of this script.
+  base_image_path = os.path.join(build_path,"hipsycl-base.sif")
+  
+  # Path where this particular run will store its output
+  job_build_path = ""
+  
+  if len(sys.argv) == 3:
+    print("Using remote repository...")
+    user = sys.argv[1]
+    branch = sys.argv[2]
+    
+    slug = user+"/hipSYCL"
+    
+    source_path = os.path.join("/tmp/",os.path.join(slug,branch))
+    job_build_path = os.path.join(build_path,"{}/{}".format(user,branch))
+    
+    ensure_directory_exists(source_path)
+    subprocess.call("git clone --recurse-submodules -b  {} https://github.com/{} {}".format(
+        branch, slug, source_path
+      ),shell=True)
+  else:
+    print("Using local repository...")
+    source_path = os.path.join(os.getcwd(),"..")
+    job_build_path = os.path.join(build_path, "local")
+  
+  ensure_directory_exists(job_build_path)
+  image_path = os.path.join(job_build_path,"hipsycl.sif")
+
+  print("Building in {} from {}".format(job_build_path,source_path))
+  
+
+  # These variables will be exported to the singularity container build process.
+  # Note: singularity makes variables of the form SINGULARITYENV_XYZ
+  # available as XYZ inside the container.
+  singularity_environment={
+    'SRCPATH' : source_path,
+    'SINGULARITYENV_SRCPATH' : source_path,
+    # Target architectures - mostly relevant for the compilation of the tests
+    'SINGULARITYENV_HIPSYCL_CUDA_GPU_ARCH' : cuda_gpu_arch,
+    'SINGULARITYENV_HIPSYCL_ROCM_GPU_ARCH' : rocm_gpu_arch,
+    # CMAKE_CXX_COMPILER used when compiling hipSYCL
+    'SINGULARITYENV_HIPSYCL_CPU_CXX' : get_from_environment_or_default("HIPSYCL_CPU_CXX","clang++-10"),
+    # CMAKE_C_COMPILER used when compiling hipSYCL
+    'SINGULARITYENV_HIPSYCL_CPU_CC' : get_from_environment_or_default("HIPSYCL_CPU_CC","clang-10"),
+    # cmake CLANG_EXECUTABLE_PATH used when compiling hipSYCL
+    'SINGULARITYENV_HIPSYCL_CLANG' : get_from_environment_or_default("HIPSYCL_CLANG","/usr/bin/clang++-10"),
+    # cmake LLVM_DIR used when compiling hipSYCL
+    'SINGULARITYENV_HIPSYCL_LLVM_DIR' : get_from_environment_or_default("HIPSYCL_LLVM_DIR","/usr/lib/llvm-10/cmake"),
+  }
+
+
+  # If it doesn't exist yet, create the image containing
+  # the hipSYCL dependencies and build environment.
+  # Building this can take some time, so once it is built
+  # it will be reused by subsequent hipSYCL builds.
+  # Only delete it if something has changed in the base image
+  # (e.g., new llvm/clang versions)
+  if not os.path.isfile(base_image_path):
+    print("""
+===========================================
+
+Building hipSYCL base image...
+target location: {}
+
+===========================================
+""".format(base_image_path))
+    raise_if_nonzero("sudo {} build {} hipsycl-env.def".format(singularity_executable, base_image_path))
+    
+  else:
+    print("""
+===========================================
+
+Reusing base image since it already exists.
+Delete:
+{}
+and rerun this script if you want to rebuild
+the base image.
+
+===========================================
+""".format(base_image_path))
+
+  # Like the base image, the hipSYCL image is not rebuilt
+  # if it already exists.
+  if not os.path.isfile(image_path):
+    print("""
+===========================================
+
+Building hipSYCL container image...
+source directory: {}
+target: {}
+
+===========================================
+""".format(source_path, image_path))
+    raise_if_nonzero("sudo -E {} build {} hipsycl.def".format(singularity_executable,image_path),
+                     environment=singularity_environment)
+  
+  else:
+    print("""
+===========================================
+
+Reusing hipSYCL image since it already exists.
+Delete:
+{}
+and rerun this script if you want to rebuild
+the image.
+
+===========================================
+""".format(image_path))
+
+  #---------------------------------------------------
+  
+  print("""
+===========================================
+Starting tests...
+===========================================
+""")
+
+  ensure_directory_exists(os.path.join(job_build_path, "external-tests"))
+
+  print("""
+-------------------------------------------
+Running SYCL parallel STL compilation test...
+-------------------------------------------
+""")
+  sycl_parallel_stl_path = os.path.join(job_build_path,"external-tests/SyclParallelSTL")
+  if not os.path.exists(sycl_parallel_stl_path):
+    raise_if_nonzero("git clone https://github.com/KhronosGroup/SyclParallelSTL {}".format(sycl_parallel_stl_path))
+
+  platforms = {
+    'cpu' : {
+      'arch' : 'dummy-arch'
+    },
+    'cuda' : {
+      'arch' : cuda_gpu_arch
+    },
+    'rocm' : {
+      'arch' : rocm_gpu_arch
+    }
+  }
+
+
+  for platform in platforms:
+    target_arch = platforms[platform]['arch']
+
+    test_environment = {
+      'SINGULARITYENV_HIPSYCL_PLATFORM' : platform,
+      'SINGULARITYENV_HIPSYCL_GPU_ARCH' : target_arch
+    }
+  
+    def compile_parallel_stl_file(filename):
+      print("Compiling SYCL parallel STL file {} for {}...".format(os.path.basename(filename), platform))
+      raise_if_nonzero("singularity exec -B {} {} /usr/bin/syclcc-clang -o {} -I {} {}".format(
+                       # Create a bind mount to let the container access the host file sysem
+                       # where SYCL parallel STL is stored
+                       sycl_parallel_stl_path,
+                       image_path,
+                       os.path.join(sycl_parallel_stl_path,os.path.basename(filename)+"."+platform),
+                       os.path.join(sycl_parallel_stl_path,"include"),
+                       os.path.join(sycl_parallel_stl_path,filename)
+                     ),
+                     environment=test_environment)
+    
+    compile_parallel_stl_file(os.path.join(sycl_parallel_stl_path, "examples/sycl_sample_00.cpp"))
+    compile_parallel_stl_file(os.path.join(sycl_parallel_stl_path, "examples/sycl_sample_01.cpp"))
+
+  print("""
+-------------------------------------------
+Running hipSYCL unit tests...
+-------------------------------------------
+""")
+
+  for platform in platforms:
+    if are_runtime_tests_allowed(platform):
+      print("Running {} unit tests...".format(platform))
+      raise_if_nonzero("singularity exec --nv {} /usr/share/hipSYCL/tests/{}/unit_tests".format(image_path,platform))
+      print("=====> Passed")
+    else:
+      print("Skipping unit tests for {}".format(platform))
+
+
+

--- a/auto-test/hipsycl-env.def
+++ b/auto-test/hipsycl-env.def
@@ -1,0 +1,64 @@
+BootStrap: docker
+From: nvidia/cuda:10.0-devel-ubuntu18.04
+
+%post
+# You may want to use a mirror better suited for your particlar
+# location. TODO: Automatically pick best mirror
+sed 's@archive.ubuntu.com@ftp.fau.de/ubuntu/@' -i /etc/apt/sources.list
+echo "Using sources:"
+cat /etc/apt/sources.list
+apt-get update
+apt-get install -y wget git unzip g++ python3 libicu-dev
+
+# ROCm
+wget -qO - http://repo.radeon.com/rocm/apt/debian/rocm.gpg.key | apt-key add -
+echo 'deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main' | tee /etc/apt/sources.list.d/rocm.list
+apt-get update
+apt install -y rocm-dev rocm-utils rocm-opencl-dev hip_base hip_hcc
+# aomp
+#wget https://github.com/ROCm-Developer-Tools/aomp/releases/download/rel_0.7-0/aomp_Ubuntu1804_0.7-0_amd64.deb
+#dpkg -i aomp_Ubuntu1804_0.7-0_amd64.deb
+
+#mkdir -p ~/aomp-build
+#cd ~/aomp-build
+#wget https://github.com/ROCm-Developer-Tools/aomp/archive/rel_0.7-0.tar.gz
+#tar xf rel_0.7-0.tar.gz
+#cd aomp-rel_0.7-0
+#cd bin
+#./clone_aomp.sh
+#./build_aomp.sh
+
+# LLVM 10
+echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main" >> /etc/apt/sources.list.d/llvm.list
+echo "deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic main" >> /etc/apt/sources.list.d/llvm.list
+## LLVM 9
+echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main" >> /etc/apt/sources.list.d/llvm.list
+echo "deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main" >> /etc/apt/sources.list.d/llvm.list
+## LLVM 8
+echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-8 main" >> /etc/apt/sources.list.d/llvm.list
+echo "deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic-8 main" >> /etc/apt/sources.list.d/llvm.list
+
+wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+apt-get update
+
+
+# LLVM 10
+apt-get install -y cmake git libllvm10 llvm-10 llvm-10-dev llvm-10-runtime clang-10 clang-tools-10 libclang-common-10-dev libclang-10-dev libclang1-10 libomp-10-dev llvm-10-tools lldb-10 lld-10
+
+# LLVM 9
+# currently there's a bug in the packaging preventing us from installing lldb and llvm-tools, which causes the cmake module to error.
+#apt-get install -y cmake git libllvm9 llvm-9 llvm-9-dev llvm-9-runtime clang-9 clang-tools-9 libclang-common-9-dev libclang-9-dev libclang1-9 libomp-9-dev llvm-9-tools lldb-9 lld-9
+
+# LLVM 8
+# LLVM conflicts with lldb-10 (which is required for the llvm cmake module), so we cannot install both simultaneously
+# apt-get install -y cmake git libllvm8 llvm-8 llvm-8-dev llvm-8-runtime clang-8 clang-tools-8 libclang-common-8-dev libclang-8-dev libclang1-8 libomp-8-dev llvm-8-tools lldb-8 lld-8
+
+
+# We need a recent version of boost for the unit tests
+wget https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.zip
+unzip boost_1_70_0.zip
+cd boost_1_70_0
+./bootstrap.sh --prefix=/usr
+# Need the || true because some targets are expected to not compile (e.g. boost.mpi)
+# due to missing dependencies (such as mpi) in which case a non-zero exit code is returned.
+./b2 install -j$(nproc) || true

--- a/auto-test/hipsycl.def
+++ b/auto-test/hipsycl.def
@@ -1,0 +1,35 @@
+BootStrap: localimage
+From: ../../hipsycl-singularity-build/hipsycl-base.sif
+
+%setup
+cp -R $SRCPATH ${SINGULARITY_ROOTFS}/src
+
+%post
+mkdir -p /build
+cd /build
+export PATH=/usr/local/cuda/bin:$PATH
+export LIBRARY_PATH=/usr/local/cuda/lib64:$LIBRARY_PATH
+cmake -DCMAKE_CXX_COMPILER=$HIPSYCL_CPU_CXX -DCMAKE_C_COMPILER=$HIPSYCL_CPU_CC -DCLANG_EXECUTABLE_PATH=$HIPSYCL_CLANG -DLLVM_DIR=$HIPSYCL_LLVM_DIR -DCMAKE_INSTALL_PREFIX=/usr  -DWITH_CPU_BACKEND=ON -DWITH_CUDA_BACKEND=ON -DWITH_ROCM_BACKEND=ON /src
+#echo "Building hipSYCL with the following cmake configuration:"
+#cmake -LA /src
+make -j$(($(nproc) -1)) install
+echo "Installed hipSYCL with configuration:"
+cat /usr/etc/hipSYCL/syclcc.json
+
+mkdir -p /usr/share/hipSYCL/tests/cpu
+mkdir -p /usr/share/hipSYCL/tests/cuda
+mkdir -p /usr/share/hipSYCL/tests/rocm
+
+cd /usr/share/hipSYCL/tests/cpu
+# For some reason, cmake does not correctly link with libboost_unit_test_framework
+# so we use this hardcoded fix..
+cmake  -DCMAKE_EXE_LINKER_FLAGS="-lboost_unit_test_framework" /src/tests
+HIPSYCL_PLATFORM=cpu make
+
+cd /usr/share/hipSYCL/tests/cuda
+cmake  -DCMAKE_EXE_LINKER_FLAGS="-lboost_unit_test_framework" /src/tests
+HIPSYCL_PLATFORM=cuda HIPSYCL_GPU_ARCH=$HIPSYCL_CUDA_GPU_ARCH make -j
+
+cd /usr/share/hipSYCL/tests/rocm
+cmake  -DCMAKE_EXE_LINKER_FLAGS="-lboost_unit_test_framework" /src/tests
+HIPSYCL_PLATFORM=rocm HIPSYCL_GPU_ARCH=$HIPSYCL_ROCM_GPU_ARCH make -j

--- a/auto-test/readme.md
+++ b/auto-test/readme.md
@@ -1,0 +1,27 @@
+# Automated, reproducible build and test infrastructure for hipSYCL
+
+`build.py` implements an infrastructure to automatically build and test hipSYCL for all supported platforms in a reproducible manner. It relies on the container solution [singularity](https://sylabs.io/docs/). It is recommended that, before submitting a pull request, the code is first tested with `build.py` since this can allow the detection of problems at a very early phase.
+
+## Prerequisites
+* `singularity` >= 3.0
+* sudo privileges. Building a container with singularity requires root privileges because singularity needs to set up container isolation.
+* python 3.
+* Internet access.
+
+## How to use
+
+There are two main ways of using `build.py`:
+* `python3 ./build.py` builds and tests a singularity image containing hipSYCL built from the local source tree in which `build.py` resides. This is useful to check own developments before publishing them.
+* `python3 ./build.py <user> <branch>` builds and tests the specified branch of the source code at `https://github.com/user/hipSYCL`. This is useful e.g. when reviewing pull requests.
+
+Building the image is done in two steps. First, a base image containing CUDA, ROCm and LLVM compiler stacks is created. This image, once created, will be reused for all future runs which can greatly speed up testing (rebuilding can be forced by deleting it again).
+Next, the actual hipSYCL image is created on top of the base image. hipSYCL is compiled (including unit tests) for all three supported platforms CPU, CUDA and ROCm.
+Once hipSYCL has been compiled successfully, tests are carried out. While compilation tests are always carried out, tests that require actually executing hipSYCL program can be disabled using the `HIPSYCL_NO_RUNTIME_TESTING` environment variable. This can be useful if you do not have both CUDA and ROCm GPUs available, preventing a successful run of the test cases for all platforms. For example,
+```
+HIPSYCL_NO_RUNTIME_TESTING=cpu,rocm python3 build.py 
+```
+will only execute tests that have been compiled for CUDA.
+
+By default, the tests will be compiled for `sm_52` (CUDA) and `gfx906` (ROCm). If this does not fit your hardware, you can change this with the `CUDA_GPU_ARCH` and `ROCM_GPU_ARCH` environment variables.
+
+The built singularity images will be stored in `../../hipsycl-singularity-build`.


### PR DESCRIPTION
This adds an initial, automatic build and test infrastructure ("auto test infrastructure") that allows
* developers to quickly build and test their code on all supported platforms (ROCm/CUDA/CPU). Tests that can actually require specific hardware (e.g. unit tests requiring GPUs) can be disabled.
* maintainers to quickly test branches from PRs

A description on how to use it is included in `auto-test/readme.md`. Note that this is only a very first attempt at this. In the future, I would like to
* expand the system to test with different base operating systems and compilers.
* Unify the current build process for singularity/docker files and Travis CI with the new auto test framework.

Note that you need the singularity container software to use the auto-test framework.