### PR TITLE
Replace calls to llvm::make_unique with std::make_unique

### DIFF
--- a/src/hipsycl_clang_plugin/FrontendPlugin.hpp
+++ b/src/hipsycl_clang_plugin/FrontendPlugin.hpp
@@ -43,8 +43,8 @@ class FrontendASTAction : public clang::PluginASTAction {
 protected:
   std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(clang::CompilerInstance &CI,
                                                         llvm::StringRef) override 
-  { 
-    return llvm::make_unique<FrontendASTConsumer>(CI);
+  {
+    return std::make_unique<FrontendASTConsumer>(CI);
   }
 
   bool ParseArgs(const clang::CompilerInstance &CI,

--- a/src/hipsycl_transform_source/CallGraph.cpp
+++ b/src/hipsycl_transform_source/CallGraph.cpp
@@ -219,7 +219,7 @@ CallGraphNode *CallGraph::getOrInsertNode(Decl *F) {
   if (Node)
     return Node.get();
 
-  Node = llvm::make_unique<CallGraphNode>(F);
+  Node = std::make_unique<CallGraphNode>(F);
   // Make Root node a parent of all functions to make sure all are reachable.
   if (F)
     Root->addCallee(Node.get());

--- a/src/hipsycl_transform_source/HipsyclTransform.cpp
+++ b/src/hipsycl_transform_source/HipsyclTransform.cpp
@@ -180,7 +180,7 @@ HipsyclTransfromFrontendAction::CreateASTConsumer(clang::CompilerInstance &CI,
                                                   clang::StringRef)
 {
   _rewriter.setSourceMgr(CI.getSourceManager(), CI.getLangOpts());
-  return llvm::make_unique<HipsyclTransformASTConsumer>(_rewriter);
+  return std::make_unique<HipsyclTransformASTConsumer>(_rewriter);
 }
 
 }


### PR DESCRIPTION
`llvm::make_unique()` was removed a couple of days ago by upstream llvm 10, so we have to switch to `std::make_unique()` to allow compilation with llvm 10. Since we are on C++ 14 anyway, `std::make_unique()` is guaranteed to be available.