### PR TITLE
Allow installation of syclcc config file in global directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,14 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(SYCLCC_CONFIG_FILE_PATH "${PROJECT_BINARY_DIR}/syclcc.json")
+set(SYCLCC_CONFIG_FILE_GLOBAL_INSTALLATION false CACHE BOOL 
+  "Whether to install the syclcc configuration file into a global directory (typically, /etc/hipSYCL). This is generally not recommended.")
+
+if(SYCLCC_CONFIG_FILE_GLOBAL_INSTALLATION)
+  set(SYCLCC_CONFIG_FILE_INSTALL_DIR /etc/hipSYCL/)
+else()
+  set(SYCLCC_CONFIG_FILE_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/etc/hipSYCL/)
+endif()
 
 add_subdirectory(src)
 
@@ -148,7 +156,7 @@ install(DIRECTORY contrib/HIP/include/ DESTINATION include/hipSYCL/)
 install(PROGRAMS bin/syclcc DESTINATION bin)
 install(PROGRAMS bin/syclcc-clang DESTINATION bin)
 
-install(FILES ${SYCLCC_CONFIG_FILE_PATH} DESTINATION etc/hipSYCL/)
+install(FILES ${SYCLCC_CONFIG_FILE_PATH} DESTINATION ${SYCLCC_CONFIG_FILE_INSTALL_DIR})
 
 set(HIPSYCL_INSTALL_LOCATION ${CMAKE_INSTALL_PREFIX})
 configure_file(${PROJECT_SOURCE_DIR}/cmake/hipsycl-config.cmake.in

--- a/bin/syclcc-clang
+++ b/bin/syclcc-clang
@@ -181,9 +181,16 @@ class syclcc_config:
     if self._config_file == None:
       # If the config file is still None at this point, probably no alternative
       # config file was supplied and the default one doesn't exist.
-      # Opening the default config file explicitly here will print a warning
-      # for the user if it doesn't exist and set the config file content to {}.
-      self._config_file = config_file(config_file_path)
+      # As a last resort, we check if there is a global config file
+      # TODO try using some more portable path here
+      global_config_file = '/etc/hipSYCL/syclcc.json'
+      if os.path.exists(global_config_file):
+        self._config_file = config_file(global_config_file)
+      else:
+        # The main purpose of opening the default config file explicitly 
+        # here is that it will print a warning for the user
+        # if it doesn't exist and set the config file content to {}.
+        self._config_file = config_file(config_file_path)
 
   def _is_hipsycl_arg(self, arg):
     accepted_args = [self._options[opt].commandline for opt in self._options]


### PR DESCRIPTION
If the cmake variable `SYCLCC_CONFIG_FILE_GLOBAL_INSTALLATION` is set to true, this will install the syclcc config file to `/etc/hipSYCL`.  Such an installation may be necessary to comply with the packaging guidelines of some distributions. See issue #121.