### PR TITLE
Improve exception diagnostics in runtime

### DIFF
--- a/include/CL/sycl/exception.hpp
+++ b/include/CL/sycl/exception.hpp
@@ -120,6 +120,7 @@ class feature_not_supported : public device_error {
 namespace detail {
 
 void check_error(hipError_t e);
+void dump_exception_info(exception_ptr eptr);
 
 }
 

--- a/src/libhipSYCL/exception.cpp
+++ b/src/libhipSYCL/exception.cpp
@@ -132,7 +132,28 @@ void check_error(hipError_t e) {
 
 }
 
+void dump_exception_info(exception_ptr eptr)
+{
+  try
+  {
+    std::rethrow_exception(eptr);
+  }
+  catch(sycl::exception& e)
+  {
+    HIPSYCL_DEBUG_ERROR << "SYCL exception details: '" << e.what() 
+      << "', HIP error code = " << e.get_cl_code() << std::endl;
+  }
+  catch(std::exception& e)
+  {
+    HIPSYCL_DEBUG_ERROR << "std exception details: " << e.what()
+      << std::endl;
+  }
+  catch(...)
+  {
+    HIPSYCL_DEBUG_ERROR << "Unknown exception type." << std::endl;
+  }
 }
 
-}
-}
+} // detail
+} // sycl
+} // cl

--- a/src/libhipSYCL/task_graph.cpp
+++ b/src/libhipSYCL/task_graph.cpp
@@ -25,6 +25,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "CL/sycl/exception.hpp"
 #include "CL/sycl/detail/task_graph.hpp"
 #include "CL/sycl/detail/debug.hpp"
 
@@ -169,6 +170,10 @@ task_graph_node::submit()
   {
     HIPSYCL_DEBUG_ERROR << "task_graph: submit() caught async error, "
                            " invoking async handler." << std::endl;
+
+    exception_ptr e = std::current_exception();
+    detail::dump_exception_info(e);
+
     // Submitted must be set to true to avoid
     // subsequent submissions
     _submitted = true;
@@ -176,7 +181,6 @@ task_graph_node::submit()
     // ToDo: Should we also consider the task as done here?
     // Or at least trigger the callback?
 
-    exception_ptr e = std::current_exception();
     _handler(sycl::exception_list{e});
   }
 
@@ -389,6 +393,8 @@ void task_graph::invoke_async_submission(async_handler error_handler)
       HIPSYCL_DEBUG_ERROR << "task_graph: caught error in invoke_async_submission, "
                              " invoking async handler." << std::endl;
       exception_ptr e = std::current_exception();
+      detail::dump_exception_info(e);
+
       error_handler(sycl::exception_list{e});
     }
   });


### PR DESCRIPTION
This adds `detail::check_error()` calls around previously unchecked HIP calls in `handler.hpp`.
Additionally, when an async exception occurs, information about that exception is now printed to the `HIPSYCL_DEBUG_ERROR` stream for easier debugging.