### PR TITLE
cmake: Optionally disable llvm version checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,16 +20,27 @@ FORCE)
   endif()
 endif()
 
-find_package(LLVM 10 CONFIG QUIET)
-if(NOT LLVM_FOUND)
-  find_package(LLVM 9 CONFIG QUIET)
+if(DISABLE_LLVM_VERSION_CHECK)
+  # just use whatever we are given - some llvm distributions do
+  # not correctly advertise their versions, and if users explicitly point
+  # us to them, let's assume they know what they are doing.
+  find_package(LLVM CONFIG)
+else()
+  # By default, try to find the newest supported LLVM version
+  find_package(LLVM 10 CONFIG QUIET)
   if(NOT LLVM_FOUND)
-    find_package(LLVM 8 CONFIG QUIET)
+    message(STATUS "No suitable LLVM 10 installation found.")
+    find_package(LLVM 9 CONFIG QUIET)
+    if(NOT LLVM_FOUND)
+      message(STATUS "No suitable LLVM 9 installation found.")
+      find_package(LLVM 8 CONFIG QUIET)
+    endif()
   endif()
-endif()
-
-if(NOT LLVM_FOUND)
-  message(SEND_ERROR "hipSYCL requires LLVM 8 or newer.")
+  if(NOT LLVM_FOUND)
+    message(SEND_ERROR "Could not find an LLVM installation of version 8 or newer. 
+      If you are sure to have passed a suitable LLVM path with -DLLVM_DIR, try again with 
+      -DDISABLE_LLVM_VERSION_CHECK=ON.")
+  endif()
 endif()
 message(STATUS "Building hipSYCL against LLVM configured from ${LLVM_DIR}")
 #find_package(Clang REQUIRED)


### PR DESCRIPTION
This introduces `-DDISABLE_LLVM_VERSION_CHECK` which can be used to work around wrong a wrong detection of the LLVM version.