### PR TITLE
clang plugin: Compile with -fno-rtti or -fno-exceptions if needed

### DIFF
--- a/src/hipsycl_clang_plugin/CMakeLists.txt
+++ b/src/hipsycl_clang_plugin/CMakeLists.txt
@@ -20,6 +20,14 @@ target_include_directories(hipSYCL_clang PRIVATE
 
 target_compile_definitions(hipSYCL_clang PRIVATE
   ${LLVM_DEFINITIONS})
+  
+if(NOT ${LLVM_ENABLE_EH})
+  target_compile_options(hipSYCL_clang PRIVATE -fno-exceptions)
+endif()
+
+if(NOT ${LLVM_ENABLE_RTTI})
+  target_compile_options(hipSYCL_clang PRIVATE -fno-rtti)
+endif()
 
 target_link_libraries(hipSYCL_clang
   ${LLVM_LIBS}


### PR DESCRIPTION
This causes cmake to check whether LLVM was built without rtti/exception support, and if necessary disables them as well in the clang plugin. This avoids possible ABI incompatibility when loading the clang plugin and addresses issue #117.