### PR TITLE
Fix missing initialization for SVM buffers constructed from const pointers

### DIFF
--- a/src/libhipSYCL/buffer.cpp
+++ b/src/libhipSYCL/buffer.cpp
@@ -394,7 +394,7 @@ void buffer_impl::write(const void* host_data, hipStream_t stream, bool async)
   }
   else
   {
-    memcpy(_buffer_pointer, _host_memory, _size);
+    memcpy(_buffer_pointer, host_data, _size);
   }
 }
 


### PR DESCRIPTION
In the SVM code path, `buffer_impl::write(const void* ptr)` was incorrectly copying data from the buffer's
host side buffer to to the device side buffer instead of from the argument `ptr` to the device side buffer.

Since, in SVM mode the host side buffer is the same as the device side buffer, this did effectively nothing.

This fixes this (arguably typo) to correctly copy from the argument to the device side buffer.
This also fixes the incorrect results reported for the readme's example in issue #56.