### PR TITLE
Do not call hipStreamSynchronize() in stream_manager destructor

### DIFF
--- a/src/libhipSYCL/queue.cpp
+++ b/src/libhipSYCL/queue.cpp
@@ -62,7 +62,6 @@ stream_manager::~stream_manager()
 {
   if(_stream != 0)
   {
-    hipStreamSynchronize(_stream);
     hipStreamDestroy(_stream);
   }
 }


### PR DESCRIPTION
Calling `hipStreamSynchronize()` is not necessary in the `stream_manager` destructor.
When the stream is not required anymore, it means that all buffers processed in that stream and all tasks related to that stream have completed.
Explicit synchronization is therefore not needed.

This can also fix crashes at the end of the program as reported in issue #56 when `hipStreamSynchronize()` is invoked after the end of `main()`.