### PR TITLE
Clang plugin: Improve shared memory detection for parallel for hierarchical invoke

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,6 +43,8 @@ add_definitions(-DHIPSYCL_DEBUG_LEVEL=${HIPSYCL_DEBUG_LEVEL})
 add_subdirectory(platform_api)
 
 add_executable(device_compilation_tests device_compilation_tests.cpp)
+target_include_directories(device_compilation_tests PRIVATE ${Boost_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(device_compilation_tests PRIVATE ${Boost_LIBRARIES})
 
 add_executable(unit_tests unit_tests.cpp)
 target_include_directories(unit_tests PRIVATE ${Boost_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
This improves the detection of shared memory variable declarations for the `parallel_for_work_group` hierarchical invoke within the Clang plugin by properly handling compound statements as well as marking memory as shared inside certain functions called from within the work-group functor.

What prompted these changes was me trying to wrap a work-group functor inside another function. This broke shared memory declarations, so I started looking into it. Initially I thought it might be sufficient to simply walk the complete call set (re-using the data structure we added for device function marking) and mark all variable declarations in those functions as shared as well. However, that is not actually desirable, as this might include functions that should very much not share their state across work items (for example state inside `parallel_for_work_item`). I then realized that having shared memory only really makes sense when you can subsequently access it from individual work items. So, as a simple heuristic, I'm only considering functions that receive a `cl::sycl::group` as one of their parameters (which would allow them to call `parallel_for_work_item`).

As mentioned above, the `storeLocalVariablesInLocalMemory` function now also handles compound statements, which I think is a rather uncontroversial change. However, there remain a few open questions regarding certain other statement types: For example, how should a for-loop be handled? Should the loop variable(s) also be marked as shared? Most likely not. But what about the body of the loop then? Since I don't have a proper usage scenario available I did not consider these cases for now.

This also includes a change that restructures the device compilation tests into a more unit-testy format. While the main objective here remains to ensure that this file compiles in the first place, there is now also some tests to check for the correct behavior of the resulting executable.