### PR TITLE
Handle lack of devices more gracefully

### DIFF
--- a/src/libhipSYCL/device.cpp
+++ b/src/libhipSYCL/device.cpp
@@ -65,7 +65,7 @@ vector_class<device> device::get_devices(
 int device::get_num_devices()
 {
   int num_devices = 0;
-  detail::check_error(hipGetDeviceCount(&num_devices));
+  hipGetDeviceCount(&num_devices);
   return num_devices;
 }
 


### PR DESCRIPTION
Just a minor change; if no devices are available we'd like for hipSYCL to return an empty list from `device::get_devices`, instead of just throwing.

Since `hipGetDeviceCount` can [only either return](http://rocm-developer-tools.github.io/HIP/group__Device.html#ga8555d5c76d88c50ddbf54ae70b568394) `hipSuccess` or `hipErrorNoDevice`, I simply removed the call to `detail::check_error` inside `device::get_num_devices` (btw, that method being public appears to be non-standard).