### PR TITLE
Reverse mapping of SYCL ids to backend ids (fixes issue #158)

### DIFF
--- a/include/CL/sycl/detail/thread_hierarchy.hpp
+++ b/include/CL/sycl/detail/thread_hierarchy.hpp
@@ -41,7 +41,7 @@ namespace detail {
 // should only be used in the implementation of more 
 // high-level functions in this file since they do
 // not take into the transformation needed to map
-// the fastest sycl index to the fastest hardware index:
+// the fastest SYCL index to the fastest hardware index:
 // Per SYCL spec, the highest dimension (e.g. dim=2 for 3D)
 // is the fastest moving spec. In HIP/CUDA, it is x.
 // Consequently, any id or range that is actually used
@@ -401,7 +401,7 @@ inline size_t get_group_id<3>(int dimension)
 
 /// Flips dimensions such that the range is consistent with the mapping
 /// of SYCL index dimensions to backend dimensions.
-/// When launching a sycl kernel, grid and blocksize should be transformed
+/// When launching a SYCL kernel, grid and blocksize should be transformed
 /// using this function.
 template<int dimensions>
 inline dim3 make_kernel_launch_range(dim3 range);

--- a/include/CL/sycl/detail/thread_hierarchy.hpp
+++ b/include/CL/sycl/detail/thread_hierarchy.hpp
@@ -37,7 +37,15 @@ namespace cl {
 namespace sycl {
 namespace detail {
 
-
+// The get_global_id_* and get_global_size_* functions 
+// should only be used in the implementation of more 
+// high-level functions in this file since they do
+// not take into the transformation needed to map
+// the fastest sycl index to the fastest hardware index:
+// Per SYCL spec, the highest dimension (e.g. dim=2 for 3D)
+// is the fastest moving spec. In HIP/CUDA, it is x.
+// Consequently, any id or range that is actually used
+// must be reversed before it can be used in a performant manner!
 inline __device__ size_t get_global_id_x()
 {
   return hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
@@ -82,12 +90,12 @@ inline sycl::id<1> get_local_id<1>()
 template<>
 __device__
 inline sycl::id<2> get_local_id<2>()
-{ return sycl::id<2>{hipThreadIdx_x, hipThreadIdx_y}; }
+{ return sycl::id<2>{hipThreadIdx_y, hipThreadIdx_x}; }
 
 template<>
 __device__
 inline sycl::id<3> get_local_id<3>()
-{ return sycl::id<3>{hipThreadIdx_x, hipThreadIdx_y, hipThreadIdx_z}; }
+{ return sycl::id<3>{hipThreadIdx_z, hipThreadIdx_y, hipThreadIdx_x}; }
 
 template<int dimensions>
 __device__
@@ -102,18 +110,19 @@ template<>
 __device__
 inline sycl::id<2> get_global_id<2>()
 {
-  return sycl::id<2>{get_global_id_x(), get_global_id_y()};
+  return sycl::id<2>{get_global_id_y(), get_global_id_x()};
 }
 
 template<>
 __device__
 inline sycl::id<3> get_global_id<3>()
 {
-  return sycl::id<3>{get_global_id_x(),
+  return sycl::id<3>{get_global_id_z(),
                     get_global_id_y(),
-                    get_global_id_z()};
+                    get_global_id_x()};
 }
 
+// For the sake of consistency, we also reverse group ids
 template<int dimensions>
 __device__
 sycl::id<dimensions> get_group_id();
@@ -127,17 +136,17 @@ template<>
 __device__
 inline sycl::id<2> get_group_id<2>()
 {
-  return sycl::id<2>{hipBlockIdx_x,
-               hipBlockIdx_y};
+  return sycl::id<2>{hipBlockIdx_y,
+               hipBlockIdx_x};
 }
 
 template<>
 __device__
 inline sycl::id<3> get_group_id<3>()
 {
-  return sycl::id<3>{hipBlockIdx_x,
+  return sycl::id<3>{hipBlockIdx_z,
                     hipBlockIdx_y,
-                    hipBlockIdx_z};
+                    hipBlockIdx_x};
 }
 
 template<int dimensions>
@@ -155,14 +164,14 @@ template<>
 __device__
 inline sycl::range<2> get_grid_size<2>()
 {
-  return sycl::range<2>{hipGridDim_x, hipGridDim_y};
+  return sycl::range<2>{hipGridDim_y, hipGridDim_x};
 }
 
 template<>
 __device__
 inline sycl::range<3> get_grid_size<3>()
 {
-  return sycl::range<3>{hipGridDim_x, hipGridDim_y, hipGridDim_z};
+  return sycl::range<3>{hipGridDim_z, hipGridDim_y, hipGridDim_x};
 }
 
 
@@ -181,14 +190,14 @@ template<>
 __device__
 inline sycl::range<2> get_local_size<2>()
 {
-  return sycl::range<2>{hipBlockDim_x, hipBlockDim_y};
+  return sycl::range<2>{hipBlockDim_y, hipBlockDim_x};
 }
 
 template<>
 __device__
 inline sycl::range<3> get_local_size<3>()
 {
-  return sycl::range<3>{hipBlockDim_x, hipBlockDim_y, hipBlockDim_z};
+  return sycl::range<3>{hipBlockDim_z, hipBlockDim_y, hipBlockDim_x};
 }
 
 template<int dimensions>
@@ -198,97 +207,222 @@ sycl::range<dimensions> get_global_size()
   return get_local_size<dimensions>() * get_grid_size<dimensions>();
 }
 
+template<int dimensions>
 __device__
-inline size_t get_global_size(int dimension)
+inline size_t get_global_size(int dimension);
+
+template<>
+__device__
+inline size_t get_global_size<1>(int dimension)
+{
+  return get_global_size_x();
+}
+
+template<>
+__device__
+inline size_t get_global_size<2>(int dimension)
+{
+  return dimension == 0 ? get_global_size_y() : get_global_size_x();
+}
+
+template<>
+__device__
+inline size_t get_global_size<3>(int dimension)
 {
   switch(dimension)
   {
   case 0:
-    return hipBlockDim_x * hipGridDim_x;
+    return get_global_size_z();
   case 1:
-    return hipBlockDim_y * hipGridDim_y;
+    return get_global_size_y();
   case 2:
-    return hipBlockDim_z * hipGridDim_z;
+    return get_global_size_x();
   }
   return 1;
 }
 
+template<int dimensions>
 __device__
-inline size_t get_grid_size(int dimension)
+inline size_t get_grid_size(int dimension);
+
+template<>
+__device__
+inline size_t get_grid_size<1>(int dimension)
+{ return hipGridDim_x; }
+
+template<>
+__device__
+inline size_t get_grid_size<2>(int dimension)
+{
+  return dimension == 0 ? hipGridDim_y : hipGridDim_x;
+}
+
+template<>
+__device__
+inline size_t get_grid_size<3>(int dimension)
 {
   switch (dimension)
   {
   case 0:
-    return hipGridDim_x;
+    return hipGridDim_z;
   case 1:
     return hipGridDim_y;
   case 2:
-    return hipGridDim_z;
+    return hipGridDim_x;
   }
   return 1;
 }
 
+template<int dimensions>
 __device__
-inline size_t get_local_size(int dimension)
+inline size_t get_local_size(int dimension);
+
+template<>
+__device__
+inline size_t get_local_size<1>(int dimension)
+{ return hipBlockDim_x; }
+
+template<>
+__device__
+inline size_t get_local_size<2>(int dimension)
 {
-  switch(dimension)
-  {
-  case 0:
-    return hipThreadIdx_x;
-  case 1:
-    return hipThreadIdx_y;
-  case 2:
-    return hipThreadIdx_z;
-  }
-  return 1;
+  return dimension == 0 ? hipBlockDim_y : hipBlockDim_x;
 }
 
+template<>
 __device__
-inline size_t get_global_id(int dimension)
-{
-  switch(dimension)
-  {
-  case 0:
-    return get_global_id_x();
-  case 1:
-    return get_global_id_y();
-  case 2:
-    return get_global_id_z();
-  }
-  return 0;
-}
-
-__device__
-inline size_t get_local_id(int dimension)
-{
-  switch(dimension)
-  {
-  case 0:
-    return hipThreadIdx_x;
-  case 1:
-    return hipThreadIdx_y;
-  case 2:
-    return hipThreadIdx_z;
-  }
-  return 0;
-}
-
-__device__
-inline size_t get_group_id(int dimension)
+inline size_t get_local_size<3>(int dimension)
 {
   switch (dimension)
   {
   case 0:
-    return hipBlockIdx_x;
+    return hipBlockDim_z;
   case 1:
-    return hipBlockIdx_y;
+    return hipBlockDim_y;
   case 2:
-    return hipBlockIdx_z;
+    return hipBlockDim_x;
+  }
+  return 1;
+}
+
+template<int dimensions>
+__device__
+inline size_t get_global_id(int dimension);
+
+template<>
+__device__
+inline size_t get_global_id<1>(int dimension)
+{ return get_global_id_x(); }
+
+template<>
+__device__
+inline size_t get_global_id<2>(int dimension)
+{ return dimension==0 ? get_global_id_y() : get_global_id_x();}
+
+template<>
+__device__
+inline size_t get_global_id<3>(int dimension)
+{
+  switch(dimension)
+  {
+  case 0:
+    return get_global_id_z();
+  case 1:
+    return get_global_id_y();
+  case 2:
+    return get_global_id_x();
   }
   return 0;
 }
 
+template<int dimensions>
+__device__
+inline size_t get_local_id(int dimension);
 
+template<>
+__device__
+inline size_t get_local_id<1>(int dimension)
+{ return hipThreadIdx_x; }
+
+template<>
+__device__
+inline size_t get_local_id<2>(int dimension)
+{ return dimension == 0 ? hipThreadIdx_y : hipThreadIdx_x; }
+
+template<>
+__device__
+inline size_t get_local_id<3>(int dimension)
+{
+  switch(dimension)
+  {
+  case 0:
+    return hipThreadIdx_z;
+  case 1:
+    return hipThreadIdx_y;
+  case 2:
+    return hipThreadIdx_x;
+  }
+  return 0;
+}
+
+template<int dimensions>
+__device__
+inline size_t get_group_id(int dimension);
+
+template<>
+__device__
+inline size_t get_group_id<1>(int dimension)
+{
+  return hipBlockIdx_x;
+}
+
+template<>
+__device__
+inline size_t get_group_id<2>(int dimension)
+{
+  return dimension == 0 ? hipBlockIdx_y : hipBlockIdx_x;
+}
+
+template<>
+__device__
+inline size_t get_group_id<3>(int dimension)
+{
+  switch (dimension)
+  {
+  case 0:
+    return hipBlockIdx_z;
+  case 1:
+    return hipBlockIdx_y;
+  case 2:
+    return hipBlockIdx_x;
+  }
+  return 0;
+}
+
+/// Flips dimensions such that the range is consistent with the mapping
+/// of SYCL index dimensions to backend dimensions.
+/// When launching a sycl kernel, grid and blocksize should be transformed
+/// using this function.
+template<int dimensions>
+inline dim3 make_kernel_launch_range(dim3 range);
+
+template<>
+inline dim3 make_kernel_launch_range<1>(dim3 range)
+{
+  return dim3(range.x, 1, 1);
+}
+
+template<>
+inline dim3 make_kernel_launch_range<2>(dim3 range)
+{
+  return dim3(range.y, range.x, 1);
+}
+
+template<>
+inline dim3 make_kernel_launch_range<3>(dim3 range)
+{
+  return dim3(range.z, range.y, range.x);
+}
 
 }
 }

--- a/include/CL/sycl/group.hpp
+++ b/include/CL/sycl/group.hpp
@@ -109,7 +109,7 @@ struct group
   size_t get_id(int dimension) const
   {
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
-    return detail::get_group_id(dimension);
+    return detail::get_group_id<dimensions>(dimension);
 #else
     return _group_id[dimension];
 #endif
@@ -129,7 +129,7 @@ struct group
   size_t get_global_range(int dimension) const
   {
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
-    return detail::get_global_size(dimension);
+    return detail::get_global_size<dimensions>(dimension);
 #else
     return _num_groups[dimension] * _local_range[dimension];
 #endif
@@ -151,7 +151,7 @@ struct group
   size_t get_local_range(int dimension) const
   {
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
-    return detail::get_local_size(dimension);
+    return detail::get_local_size<dimensions>(dimension);
 #else
     return _local_range[dimension];
 #endif
@@ -175,7 +175,7 @@ struct group
   size_t get_group_range(int dimension) const
   {
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
-    return detail::get_grid_size(dimension);
+    return detail::get_grid_size<dimensions>(dimension);
 #else
     return _num_groups[dimension];
 #endif
@@ -185,7 +185,7 @@ struct group
   size_t operator[](int dimension) const
   {
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
-    return detail::get_group_id(dimension);
+    return detail::get_group_id<dimensions>(dimension);
 #else
     return _group_id[dimension];
 #endif
@@ -391,8 +391,11 @@ private:
                                   workItemFunctionT&& func) const
   {
     const range<2> physical_range = this->get_local_range();
-    for(size_t i = hipThreadIdx_x; i < flexibleRange.get(0); i += physical_range.get(0))
-      for(size_t j = hipThreadIdx_y; j < flexibleRange.get(1); j += physical_range.get(1))
+    // Reverse dimensions of hipThreadIdx_* compared to flexibleRange.get()
+    // to make sure that the fastest index in SYCL terminology is mapped
+    // to the fastest index of the backend
+    for(size_t i = hipThreadIdx_y; i < flexibleRange.get(0); i += physical_range.get(0))
+      for(size_t j = hipThreadIdx_x; j < flexibleRange.get(1); j += physical_range.get(1))
       {
   #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
         h_item<2> idx{id<2>{i,j}, flexibleRange};
@@ -409,9 +412,9 @@ private:
                                   workItemFunctionT&& func) const
   { 
     const range<3> physical_range = this->get_local_range();
-    for(size_t i = hipThreadIdx_x; i < flexibleRange.get(0); i += physical_range.get(0))
+    for(size_t i = hipThreadIdx_z; i < flexibleRange.get(0); i += physical_range.get(0))
       for(size_t j = hipThreadIdx_y; j < flexibleRange.get(1); j += physical_range.get(1))
-        for(size_t k = hipThreadIdx_z; k < flexibleRange.get(2); k += physical_range.get(2))
+        for(size_t k = hipThreadIdx_x; k < flexibleRange.get(2); k += physical_range.get(2))
         {
   #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
           h_item<3> idx{id<3>{i,j,k}, flexibleRange};

--- a/include/CL/sycl/h_item.hpp
+++ b/include/CL/sycl/h_item.hpp
@@ -91,7 +91,7 @@ public:
   size_t get_global_range(int dimension) const
   {
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
-    return detail::get_grid_size(dimension) * this->_logical_range[dimension];
+    return detail::get_grid_size<dimensions>(dimension) * this->_logical_range[dimension];
 #else
     return this->_num_groups[dimension] * this->_logical_range[dimension];
 #endif
@@ -111,7 +111,7 @@ public:
   size_t get_global_id(int dimension) const
   {
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
-    return detail::get_group_id(dimension) * _logical_range[dimension] + _logical_local_id[dimension];
+    return detail::get_group_id<dimensions>(dimension) * _logical_range[dimension] + _logical_local_id[dimension];
 #else
     return _group_id[dimension] * _logical_range[dimension] + _logical_local_id[dimension];
 #endif
@@ -182,7 +182,7 @@ public:
   size_t get_physical_local_range(int dimension) const
   {
 #ifdef SYCL_DEVICE_ONLY
-    return detail::get_local_size(dimension);
+    return detail::get_local_size<dimensions>(dimension);
 #else
     return 1;
 #endif
@@ -205,7 +205,7 @@ public:
   size_t get_physical_local_id(int dimension) const
   {
 #ifdef SYCL_DEVICE_ONLY
-    return detail::get_local_id(dimension);
+    return detail::get_local_id<dimensions>(dimension);
 #else
     return 0;
 #endif

--- a/include/CL/sycl/handler.hpp
+++ b/include/CL/sycl/handler.hpp
@@ -933,10 +933,10 @@ private:
 #endif
       {
         __hipsycl_launch_kernel(detail::dispatch::device::parallel_for_kernel<KernelName>,
-                              detail::make_kernel_launch_range<dimensions>(grid),
-                              detail::make_kernel_launch_range<dimensions>(block),
-                              shared_mem_size, stream->get_stream(),
-                              kernelFunc, numWorkItems);
+                                detail::make_kernel_launch_range<dimensions>(grid),
+                                detail::make_kernel_launch_range<dimensions>(block),
+                                shared_mem_size, stream->get_stream(),
+                                kernelFunc, numWorkItems);
       }
 
       return detail::task_state::enqueued;
@@ -981,10 +981,10 @@ private:
 #endif
       {
         __hipsycl_launch_kernel(detail::dispatch::device::parallel_for_kernel_with_offset<KernelName>,
-                        detail::make_kernel_launch_range<dimensions>(grid),
-                        detail::make_kernel_launch_range<dimensions>(block),
-                        shared_mem_size, stream->get_stream(),
-                        kernelFunc, numWorkItems, offset);
+                                detail::make_kernel_launch_range<dimensions>(grid),
+                                detail::make_kernel_launch_range<dimensions>(block),
+                                shared_mem_size, stream->get_stream(),
+                                kernelFunc, numWorkItems, offset);
       }
 
       return detail::task_state::enqueued;
@@ -1028,19 +1028,19 @@ private:
         // for ndrange kernels until we have support in the clang
         // plugin for dealing with barriers
         __hipsycl_launch_kernel(detail::dispatch::host::parallel_for_ndrange_kernel,
-                          detail::make_kernel_launch_range<dimensions>(grid),
-                          detail::make_kernel_launch_range<dimensions>(block),
-                          shared_mem_size, stream->get_stream(),
-                          kernelFunc, offset);
+                                detail::make_kernel_launch_range<dimensions>(grid),
+                                detail::make_kernel_launch_range<dimensions>(block),
+                                shared_mem_size, stream->get_stream(),
+                                kernelFunc, offset);
       }
       else
 #endif
       {
         __hipsycl_launch_kernel(detail::dispatch::device::parallel_for_ndrange_kernel<KernelName>,
-                          detail::make_kernel_launch_range<dimensions>(grid),
-                          detail::make_kernel_launch_range<dimensions>(block),
-                          shared_mem_size, stream->get_stream(),
-                          kernelFunc, offset);
+                                detail::make_kernel_launch_range<dimensions>(grid),
+                                detail::make_kernel_launch_range<dimensions>(block),
+                                shared_mem_size, stream->get_stream(),
+                                kernelFunc, offset);
       }
 
       return detail::task_state::enqueued;
@@ -1081,10 +1081,10 @@ private:
 #endif
       {
         __hipsycl_launch_kernel(detail::dispatch::device::parallel_for_workgroup<KernelName>,
-                          detail::make_kernel_launch_range<dimensions>(grid),
-                          detail::make_kernel_launch_range<dimensions>(block),
-                          shared_mem_size, stream->get_stream(),
-                          kernelFunc, workGroupSize);
+                                detail::make_kernel_launch_range<dimensions>(grid),
+                                detail::make_kernel_launch_range<dimensions>(block),
+                                shared_mem_size, stream->get_stream(),
+                                kernelFunc, workGroupSize);
       }
 
 

--- a/include/CL/sycl/handler.hpp
+++ b/include/CL/sycl/handler.hpp
@@ -933,7 +933,9 @@ private:
 #endif
       {
         __hipsycl_launch_kernel(detail::dispatch::device::parallel_for_kernel<KernelName>,
-                              grid, block, shared_mem_size, stream->get_stream(),
+                              detail::make_kernel_launch_range<dimensions>(grid),
+                              detail::make_kernel_launch_range<dimensions>(block),
+                              shared_mem_size, stream->get_stream(),
                               kernelFunc, numWorkItems);
       }
 
@@ -979,7 +981,9 @@ private:
 #endif
       {
         __hipsycl_launch_kernel(detail::dispatch::device::parallel_for_kernel_with_offset<KernelName>,
-                        grid, block, shared_mem_size, stream->get_stream(),
+                        detail::make_kernel_launch_range<dimensions>(grid),
+                        detail::make_kernel_launch_range<dimensions>(block),
+                        shared_mem_size, stream->get_stream(),
                         kernelFunc, numWorkItems, offset);
       }
 
@@ -1024,14 +1028,18 @@ private:
         // for ndrange kernels until we have support in the clang
         // plugin for dealing with barriers
         __hipsycl_launch_kernel(detail::dispatch::host::parallel_for_ndrange_kernel,
-                          grid, block, shared_mem_size, stream->get_stream(),
+                          detail::make_kernel_launch_range<dimensions>(grid),
+                          detail::make_kernel_launch_range<dimensions>(block),
+                          shared_mem_size, stream->get_stream(),
                           kernelFunc, offset);
       }
       else
 #endif
       {
         __hipsycl_launch_kernel(detail::dispatch::device::parallel_for_ndrange_kernel<KernelName>,
-                          grid, block, shared_mem_size, stream->get_stream(),
+                          detail::make_kernel_launch_range<dimensions>(grid),
+                          detail::make_kernel_launch_range<dimensions>(block),
+                          shared_mem_size, stream->get_stream(),
                           kernelFunc, offset);
       }
 
@@ -1073,7 +1081,9 @@ private:
 #endif
       {
         __hipsycl_launch_kernel(detail::dispatch::device::parallel_for_workgroup<KernelName>,
-                          grid, block, shared_mem_size, stream->get_stream(),
+                          detail::make_kernel_launch_range<dimensions>(grid),
+                          detail::make_kernel_launch_range<dimensions>(block),
+                          shared_mem_size, stream->get_stream(),
                           kernelFunc, workGroupSize);
       }
 

--- a/include/CL/sycl/nd_item.hpp
+++ b/include/CL/sycl/nd_item.hpp
@@ -63,7 +63,7 @@ struct nd_item
   size_t get_global_id(int dimension) const
   {
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
-    return detail::get_global_id(dimension) + _offset->get(dimension);
+    return detail::get_global_id<dimensions>(dimension) + _offset->get(dimension);
 #else
     return this->_global_id[dimension] + (*_offset)[dimension];
 #endif
@@ -107,7 +107,7 @@ struct nd_item
   size_t get_local_id(int dimension) const
   {
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
-    return detail::get_local_id(dimension);
+    return detail::get_local_id<dimensions>(dimension);
 #else
     return this->_local_id[dimension];
 #endif
@@ -143,7 +143,7 @@ struct nd_item
   size_t get_group(int dimension) const
   {
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
-    return detail::get_group_id(dimension);
+    return detail::get_group_id<dimensions>(dimension);
 #else
     return this->_group_id[dimension];
 #endif


### PR DESCRIPTION
This causes SYCL work item/group ids to be mapped to the HIP/CUDA backend in reverse order:
2D example:
id[0] -> hipThreadIdx_y
id[1] -> hipThreadIdx_x

See issue #158 for more details.

This can yield performance benefits since SYCL encourages the user to use dimensions-1 as fastest moving index, while HIP/CUDA uses the x component as fastest moving index.
While this primarily affects work items, the reversal is also done for group ids to remain consistent.

To make everything work again, ranges (in particular related to kernel call configurations) are also reversed.

While this PR passes the unit tests, due to the fundamental nature of this change and the great potential for breakage, I will leave this PR open a couple more days than usual to give everybody a chance to test.