### PR TITLE
Add dedicated data transfer stream for queues

### DIFF
--- a/include/CL/sycl/queue.hpp
+++ b/include/CL/sycl/queue.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
  *
- * Copyright (c) 2018,2019 Aksel Alpay
+ * Copyright (c) 2018, 2019 Aksel Alpay and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -168,6 +168,8 @@ public:
 
   hipStream_t get_hip_stream() const;
   detail::stream_ptr get_stream() const;
+  /// Secondary stream used for data transfers (concurrent copy and execution).
+  detail::stream_ptr get_transfer_stream() const;
 
 private:
 
@@ -180,6 +182,7 @@ private:
 
   device _device;
   detail::stream_ptr _stream;
+  detail::stream_ptr _transfer_stream;
   async_handler _handler;
   detail::queue_submission_hooks_ptr _hooks;
 

--- a/src/libhipSYCL/accessor.cpp
+++ b/src/libhipSYCL/accessor.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
  *
- * Copyright (c) 2018 Aksel Alpay
+ * Copyright (c) 2018, 2019 Aksel Alpay and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -69,7 +69,7 @@ void* obtain_device_access(buffer_ptr buff,
   void* access_ptr = nullptr;
 
 #ifndef HIPSYCL_CPU_EMULATE_SEPARATE_MEMORY
-  if(cgh.get_stream()->get_device().is_host())
+  if(cgh.get_transfer_stream()->get_device().is_host())
   {
     // The "device" access that we make is actually a "host" access
     // since we are running on the host device!
@@ -85,8 +85,8 @@ void* obtain_device_access(buffer_ptr buff,
     auto task_graph_node =
         detail::buffer_impl::access_host(buff,
                                          access_mode,
-                                         cgh.get_stream(),
-                                         cgh.get_stream()->get_error_handler());
+                                         cgh.get_transfer_stream(),
+                                         cgh.get_transfer_stream()->get_error_handler());
 
     cgh.add_access(buff, access_mode, task_graph_node);
   }
@@ -98,8 +98,8 @@ void* obtain_device_access(buffer_ptr buff,
     auto task_graph_node =
         detail::buffer_impl::access_device(buff,
                                             access_mode,
-                                            cgh.get_stream(),
-                                            cgh.get_stream()->get_error_handler());
+                                            cgh.get_transfer_stream(),
+                                            cgh.get_transfer_stream()->get_error_handler());
 
     cgh.add_access(buff, access_mode, task_graph_node);
 

--- a/src/libhipSYCL/handler.cpp
+++ b/src/libhipSYCL/handler.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
  *
- * Copyright (c) 2018 Aksel Alpay
+ * Copyright (c) 2018, 2019 Aksel Alpay and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -46,6 +46,11 @@ hipStream_t handler::get_hip_stream() const
 detail::stream_ptr handler::get_stream() const
 {
   return _queue->get_stream();
+}
+
+detail::stream_ptr handler::get_transfer_stream() const
+{
+  return _queue->get_transfer_stream();
 }
 
 void handler::select_device() const

--- a/src/libhipSYCL/queue.cpp
+++ b/src/libhipSYCL/queue.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
  *
- * Copyright (c) 2018 Aksel Alpay
+ * Copyright (c) 2018, 2019 Aksel Alpay and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -178,6 +178,10 @@ void queue::init()
       _device,
       _handler}};
 
+  this->_transfer_stream = detail::stream_ptr{new detail::stream_manager{
+      _device,
+      _handler}};
+
   this->_hooks = detail::queue_submission_hooks_ptr{
         new detail::queue_submission_hooks{}};
 }
@@ -216,6 +220,9 @@ hipStream_t queue::get_hip_stream() const
 
 detail::stream_ptr queue::get_stream() const
 { return _stream; }
+
+detail::stream_ptr queue::get_transfer_stream() const
+{ return _transfer_stream; }
 
 }// namespace sycl
 }// namespace cl


### PR DESCRIPTION
This adds a secondary HIP stream to each SYCL queue, which is intended for submitting data transfers.  The stream is created for the same device as the primary stream, and can be accessed using `[queue|handler]::get_transfer_stream`. Since modern GPUs support "concurrent copy and execution", this allows hipSYCL to perform some data transfers concurrently with kernel executions, potentially reducing launch latency for subsequent kernel tasks. Both implicit (through device accessors) and explicit (through copy operations) data transfers are changed to make use of the new stream.

Now I'm not sure (and I haven't tested this), whether this allows uploads and downloads to be executed concurrently as well (as modern GPUs typically have two copy engines, one for upload and one for download). I suspect not, but I think this change should at least cover typical applications. Ultimately I think hipSYCL should move away from the `SYCL queue == HIP stream` correspondence, and instead use some kind of stream pool. This would then also allow for concurrent kernel executions (for better occupancy).

Note that I didn't add corresponding `get_hip_transfer_stream` members to `queue` and `handler`, as `get_hip_stream` doesn't seem to be used anywhere.

----

Here's an example that demonstrates the changes:

```cpp
#include <cstdio>
#include <list>

#include <CL/sycl.hpp>

int main(int argc, char* argv[]) {
	cl::sycl::queue queue;

	cl::sycl::buffer<uint64_t, 1> buf_a(1024);
	cl::sycl::buffer<uint64_t, 1> buf_b(1024);
	std::list<std::pair<std::string, cl::sycl::event>> events;

	queue
	    .submit([&](cl::sycl::handler& cgh) {
		    auto dw_a = buf_a.get_access<cl::sycl::access::mode::discard_write>(cgh);
		    auto dw_b = buf_b.get_access<cl::sycl::access::mode::discard_write>(cgh);
		    cgh.parallel_for<class Initialize>(buf_a.get_range(), [=](cl::sycl::item<1> item) {
			    dw_a[item] = 5e7;
			    dw_b[item] = 5e7;
		    });
	    })
	    .wait();

	auto kernel_e = queue.submit([&](cl::sycl::handler& cgh) {
		auto rw_a = buf_a.get_access<cl::sycl::access::mode::read_write>(cgh);
		cgh.parallel_for<class Kernel>(buf_a.get_range(), [=](cl::sycl::item<1> item) {
			// Do some work
			const auto max = rw_a[item];
			double sum = 0.f;
			while(sum < max) {
				sum += 1.0;
			}
			rw_a[item] = sum;
		});
	});

	uint64_t copied_value = 1337;
	auto copy_e = queue.submit([&](cl::sycl::handler& cgh) {
		auto r_b = buf_b.get_access<cl::sycl::access::mode::read>(cgh, 1);
		cgh.copy(r_b, &copied_value);
	});

	events.push_back(std::make_pair("kernel", kernel_e));
	events.push_back(std::make_pair("copy", copy_e));

	auto it = events.begin();
	while(true) {
		const auto status = it->second.get_info<cl::sycl::info::event::command_execution_status>();
		if(status == cl::sycl::info::event_command_status::complete) {
			printf("%s done\n", it->first.c_str());
			if(it->first == "copy") { printf("copied value: %ld\n", copied_value); }
			it = events.erase(it);
		} else {
			++it;
		}

		if(it == events.end()) {
			if(events.empty()) break;
			it = events.begin();
		}
	}
}
```

Output before the patch:
```
Oct 21 13:55:45 kernel done
Oct 21 13:55:45 copy done
Oct 21 13:55:45 copied value: 50000000
```

Output after the patch:
```
Oct 21 13:56:54 copy done
Oct 21 13:56:54 copied value: 50000000
Oct 21 13:56:56 kernel done
```

While explicit copy operations are my primary use case for this, the same works for the implicit transfers generated by `buffer::get_access` calls.
