### PR TITLE
Fixing Issue #149 by removing __cudaPopCallConfiguration() call

### DIFF
--- a/include/CL/sycl/backend/clang.hpp
+++ b/include/CL/sycl/backend/clang.hpp
@@ -58,17 +58,10 @@ static inline void __hipsycl_push_kernel_call(dim3 grid, dim3 block, size_t shar
 #endif
 }
 
-static inline void __hipsycl_pop_kernel_call()
-{
-#ifdef __CUDA__
-  __cudaPopCallConfiguration();
-#endif
-}
 
 #define __hipsycl_launch_kernel(f, grid, block, shared_mem, stream, ...) \
   __hipsycl_push_kernel_call(grid, block, shared_mem, stream); \
-  f(__VA_ARGS__); \
-  __hipsycl_pop_kernel_call();
+  f(__VA_ARGS__);
   
 
 #else


### PR DESCRIPTION
As discussed in issue #[149](https://github.com/illuhad/hipSYCL/issues/149) the removal of the  __cudaPopCallConfiguration() call fixes the segmentation fault that surfaced when using Cuda 10.1.