### PR TITLE
Add multi-GPU example

### DIFF
--- a/examples/multi_gpu/multi_gpu_vec_add_async.cpp
+++ b/examples/multi_gpu/multi_gpu_vec_add_async.cpp
@@ -1,0 +1,96 @@
+#include <memory>
+#include <cassert>
+#include <iostream>
+
+#include <CL/sycl.hpp>
+
+using data_type = float;
+
+class device_context
+{
+public:
+  device_context (
+    size_t size_arg,
+    const data_type * a,
+    const data_type * b,
+    const data_type * c,
+    cl::sycl::device &device)
+  : size (size_arg)
+  , queue (device)
+  , buff_a (a, size)
+  , buff_b (b, size)
+  , buff_c (c, size)
+  {
+    assert(a.size() == b.size());
+  }
+
+  const size_t size {};
+  cl::sycl::queue queue;
+  cl::sycl::buffer<data_type> buff_a;
+  cl::sycl::buffer<data_type> buff_b;
+  cl::sycl::buffer<data_type> buff_c;
+};
+
+void add(std::vector<std::unique_ptr<device_context>> &contexts)
+{
+  for (auto &context: contexts)
+    {
+      cl::sycl::range<1> work_items{context->size};
+
+      auto e = context->queue.submit([&](cl::sycl::handler& cgh){
+        auto access_a = context->buff_a.get_access<cl::sycl::access::mode::read>(cgh);
+        auto access_b = context->buff_b.get_access<cl::sycl::access::mode::read>(cgh);
+        auto access_c = context->buff_c.get_access<cl::sycl::access::mode::write>(cgh);
+
+        cgh.parallel_for<class vector_add>(work_items,
+                                           [=] (cl::sycl::id<1> tid) {
+                                             access_c[tid] = access_a[tid] + access_b[tid];
+                                           });
+      });
+    }
+}
+
+int main()
+{
+  std::vector<cl::sycl::device> devices = cl::sycl::device::get_devices ();
+
+  const unsigned int n = 100'000'000;
+
+  std::vector<data_type> a (n, 1);
+  std::vector<data_type> b (n, 2);
+  std::vector<data_type> c (n);
+
+  double single_gpu_elapsed_time {};
+
+  for (unsigned int devices_count = 1; devices_count <= devices.size (); devices_count++)
+    {
+      std::vector<std::unique_ptr<device_context>> contexts;
+      const unsigned int chunk_size = n / devices_count;
+
+      for (unsigned int dev_id = 0; dev_id < devices_count; dev_id++)
+        {
+          const unsigned int beg = chunk_size * dev_id;
+          const unsigned int end = dev_id == devices_count - 1 ? n : chunk_size * (dev_id + 1);
+          const unsigned int size = end - beg;
+
+          contexts.push_back (std::make_unique<device_context> (
+            size,
+            a.data () + beg,
+            b.data () + beg,
+            c.data () + beg,
+            devices[dev_id]));
+        }
+
+      auto begin = std::chrono::system_clock::now (); // TODO Implement event profiler
+      add(contexts);
+      auto end = std::chrono::system_clock::now ();
+      const std::chrono::duration<double> duration = end - begin;
+      std::cout << duration.count () << "s on " << devices_count << " devices";
+
+      if (devices_count == 1)
+        single_gpu_elapsed_time = duration.count ();
+      else
+        std::cout << " (speedup = " << single_gpu_elapsed_time / duration.count () << ")";
+      std::cout << "\n";
+    }
+}

--- a/examples/multi_gpu/multi_gpu_vec_add_multi_thread.cpp
+++ b/examples/multi_gpu/multi_gpu_vec_add_multi_thread.cpp
@@ -1,0 +1,83 @@
+#include <memory>
+#include <thread>
+#include <cassert>
+#include <iostream>
+
+#include <CL/sycl.hpp>
+
+using data_type = float;
+
+class device_context
+{
+public:
+  device_context (
+    size_t size_arg,
+    const data_type * a,
+    const data_type * b,
+    const data_type * c,
+    cl::sycl::device &device)
+    : size (size_arg)
+    , queue (device)
+    , buff_a (a, size)
+    , buff_b (b, size)
+    , buff_c (c, size)
+  {
+    assert(a.size() == b.size());
+  }
+
+  const size_t size {};
+  cl::sycl::queue queue;
+  cl::sycl::buffer<data_type> buff_a;
+  cl::sycl::buffer<data_type> buff_b;
+  cl::sycl::buffer<data_type> buff_c;
+};
+
+
+void add(device_context &context)
+{
+  cl::sycl::range<1> work_items{context.size};
+
+  context.queue.submit([&](cl::sycl::handler& cgh){
+    auto access_a = context.buff_a.get_access<cl::sycl::access::mode::read>(cgh);
+    auto access_b = context.buff_b.get_access<cl::sycl::access::mode::read>(cgh);
+    auto access_c = context.buff_c.get_access<cl::sycl::access::mode::write>(cgh);
+
+    cgh.parallel_for<class vector_add>(work_items,
+                                       [=] (cl::sycl::id<1> tid) {
+                                         access_c[tid] = access_a[tid] + access_b[tid];
+                                       });
+  });
+}
+
+int main()
+{
+  std::vector<cl::sycl::device> devices = cl::sycl::device::get_devices ();
+  std::vector<std::thread> workers;
+
+  const unsigned int n = 100'000'000;
+  std::vector<data_type> a (n, 1);
+  std::vector<data_type> b (n, 2);
+  std::vector<data_type> c (n);
+
+  for (unsigned int dev_id = 0; dev_id < devices.size (); dev_id++)
+    {
+      const unsigned int chunk_size = n / devices.size ();
+      const unsigned int beg = chunk_size * dev_id;
+      const unsigned int end = dev_id == devices.size () - 1 ? n : chunk_size * (dev_id + 1);
+      const unsigned int size = end - beg;
+      auto &dev = devices[dev_id];
+
+      workers.emplace_back ([&] () {
+        device_context context (
+          size,
+          a.data () + beg,
+          b.data () + beg,
+          c.data () + beg,
+          dev);
+        add (context);
+      });
+    }
+
+  for (auto &worker: workers)
+    worker.join ();
+}


### PR DESCRIPTION
If I understand it correctly, memory for buffers is allocated in buffer object construction. The memory is allocated for the device that was specified in queue construction. I haven't found a different way of specifying the buffer device, so I'm constructing buffers immediately after queue construction. If there is a better way, I'll be glad to hear about it and update the example. Also, I would like to use an event profiler, but it seems that it hasn't implemented yet. If profiling and events are not in progress, I would like to implement it.