### PR TITLE
Fix race condition in task graph node

### DIFF
--- a/include/CL/sycl/detail/task_graph.hpp
+++ b/include/CL/sycl/detail/task_graph.hpp
@@ -32,6 +32,7 @@
 #include "../backend/backend.hpp"
 
 #include "stream.hpp"
+#include "util.hpp"
 #include "async_worker.hpp"
 
 #include <atomic>
@@ -92,6 +93,7 @@ private:
 
   task_functor _tf;
   vector_class<task_graph_node_ptr> _requirements;
+  spin_lock _requirements_lock; // prevent _requirements from being cleared while iterated over
 
   stream_ptr _stream;
   async_handler _handler;


### PR DESCRIPTION
We recently discovered the source for an intermittent, but rather frequent crash we experienced in hipSYCL. By bisecting we traced it back to 2adb3cd8.

I'm not 100% sure about the best way to fix this issue, since I don't know the internal details of hipsycl task scheduling. What I did was add a spinlock to protect access to that vector. (We used a spinlock as that should have basically 0 initialization overhead when creating a new task graph node)