### PR TITLE
Fixed syclcc bug, preventing compilation against recent rocm

### DIFF
--- a/bin/syclcc-clang
+++ b/bin/syclcc-clang
@@ -467,11 +467,17 @@ class clang_plugin_compiler:
           "-L"+hipsycl_library_path,
           "-lhipSYCL_cuda"
         ]
+        self._compiler_args=["-I"+os.path.join(config.hipsycl_installation_path, "include/hipSYCL/")]
 
-      self._compiler_args = ["-x", "cuda",
-                             "--cuda-gpu-arch=" + config.target_arch,
-                             "--cuda-path=" + config.cuda_path,
-                             "-I"+os.path.join(config.hipsycl_installation_path, "include/hipSYCL/")]
+      else:
+        self._compiler_args = [
+          "-I"+os.path.join(config.hipsycl_installation_path, "contrib/HIP/include")
+        ]
+      
+      self._compiler_args += ["-x", "cuda",
+                              "--cuda-gpu-arch=" + config.target_arch,
+                              "--cuda-path=" + config.cuda_path]
+      
     elif target == hipsycl_platform.HIP:
       self._target = "hip"
       
@@ -508,10 +514,6 @@ class clang_plugin_compiler:
         # We would also have to add include/hipSYCL here, but since we do
         # not want to use the bundled HIP on ROCm, we add these includes
         # in the platform specific section above
-      ]
-    else:
-      self._common_compiler_args += [
-        "-I"+os.path.join(config.hipsycl_installation_path, "contrib/HIP/include")
       ]
 
   def _get_rocm_clang_include_path(self, config):


### PR DESCRIPTION
Hip headers for the Cuda build are now not included when we compile for HiP. 

This has caused issues when compiling hipSYCL against more recent versions of rocm, because instead of the headers from the rocm installation, the headers from the contrib/HIP directory were considered. 

Now we only include these headers when we are compiling with Cuda support