### PR TITLE
Use CLANG_INCLUDE_PATH for building hipSYCL_clang

### DIFF
--- a/src/hipsycl_clang_plugin/CMakeLists.txt
+++ b/src/hipsycl_clang_plugin/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(hipSYCL_clang SHARED
 target_include_directories(hipSYCL_clang PRIVATE
   ${LLVM_INCLUDE_DIRS}
   ${CMAKE_CURRENT_SOURCE_DIR}
+  ${CLANG_INCLUDE_PATH}
   ../../include)
 
 target_compile_definitions(hipSYCL_clang PRIVATE


### PR DESCRIPTION
This is needed to make the clang include directory available while building hipSYCL_clang. Without this the build fails for me with `fatal error: 'clang/Frontend/FrontendPluginRegistry.h' file not found`.

With this I can build hipSYCL and compile the example given in the README.