### PR TITLE
Fix kernel outlining for forward declared functions

### DIFF
--- a/tests/device_compilation_tests.cpp
+++ b/tests/device_compilation_tests.cpp
@@ -116,6 +116,7 @@ BOOST_AUTO_TEST_CASE(complex_device_call_graph) {
   BOOST_REQUIRE(acc[0] == 37);
 }
 
+
 template<int T, int* I, typename U>
 class complex_kn;
 
@@ -265,6 +266,37 @@ BOOST_AUTO_TEST_CASE(hierarchical_invoke_shared_memory) {
     }
   }
 }
+
+
+void forward_declared2();
+
+template<class T>
+void forward_declared1();
+
+template<class T>
+class forward_declared_test_kernel;
+
+BOOST_AUTO_TEST_CASE(forward_declared_function) {
+  cl::sycl::queue q;
+
+  // Here, the clang plugin must build the correct call graph
+  // and emit both forward_declared1() and forward_declared2()
+  // to device code, even though the call expression below refers
+  // to the forward declarations above.
+  q.submit([&](cl::sycl::handler& cgh){
+    cgh.single_task<forward_declared_test_kernel<int>>([=](){
+      forward_declared1<int>();
+    });  
+  });
+
+  q.wait_and_throw();
+}
+
+
+template <class T>
+void forward_declared1(){forward_declared2();}
+
+void forward_declared2(){}
 
 BOOST_AUTO_TEST_SUITE_END() // NOTE: Make sure not to add anything below this line
 


### PR DESCRIPTION
Issue found through discussion with @AndreiCNitu. Consider the following code, which currently does not compile:

```
void forward_declared2();
void forward_declared1();

...

q.submit([&](cl::sycl::handler& cgh){
  cgh.single_task<class test>([=](){
    forward_declared1();
  });  
});
...

void forward_declared1(){forward_declared2();}
void forward_declared2(){}
```

The hipSYCL clang plugin currently fails to correctly outline such kernels. This is because the call expression in the kernel then references only the forward declared function, which causes 
* the `CompleteCallSet` to miss the portion of the call graph that is invoked by the forward declared function
* the clang plugin not to emit the forward declared function to device code, causing linker errors.

This PR fixes the issue by making the `CompleteCallSet` attempt to find the definition for each function that it investigates, and if possible, investigate the definition instead of the declaration.