### PR TITLE
Add accessor::operator[] for atomic mode

### DIFF
--- a/include/CL/sycl/accessor.hpp
+++ b/include/CL/sycl/accessor.hpp
@@ -608,6 +608,9 @@ accessMode == access::mode::discard_read_write) && dimensions == 1) */
       return atomic<dataT, access::address_space::global_space> { global_ptr<dataT>(_ptr + detail::linear_id<dimensions>::get(index, _buffer_range)) };
   }
 
+  template<int D = dimensions,
+           access::mode M = accessmode,
+           typename = std::enable_if_t<(D == 0) && (M == access::mode::atomic)>>
   atomic<dataT, access::address_space::global_space> operator[](size_t index) const
   {
       return atomic<dataT, access::address_space::global_space> { global_ptr<dataT>(_ptr + index) };

--- a/include/CL/sycl/accessor.hpp
+++ b/include/CL/sycl/accessor.hpp
@@ -593,6 +593,7 @@ accessMode == access::mode::discard_read_write) && dimensions == 1) */
   template<int D = dimensions,
            access::mode M = accessmode,
            typename = std::enable_if_t<M == access::mode::atomic && D == 0>>
+  HIPSYCL_UNIVERSAL_TARGET
   operator atomic<dataT, access::address_space::global_space> () const
   {
       return atomic<dataT, access::address_space::global_space> { global_ptr<dataT>(_ptr) };
@@ -602,6 +603,7 @@ accessMode == access::mode::discard_read_write) && dimensions == 1) */
   template<int D = dimensions,
            access::mode M = accessmode,
            typename = std::enable_if_t<(D > 0) && (M == access::mode::atomic)>>
+  HIPSYCL_UNIVERSAL_TARGET
   atomic<dataT, access::address_space::global_space> operator[](
       id<dimensions> index) const
   {
@@ -611,6 +613,7 @@ accessMode == access::mode::discard_read_write) && dimensions == 1) */
   template<int D = dimensions,
            access::mode M = accessmode,
            typename = std::enable_if_t<(D == 0) && (M == access::mode::atomic)>>
+  HIPSYCL_UNIVERSAL_TARGET
   atomic<dataT, access::address_space::global_space> operator[](size_t index) const
   {
       return atomic<dataT, access::address_space::global_space> { global_ptr<dataT>(_ptr + index) };

--- a/include/CL/sycl/accessor.hpp
+++ b/include/CL/sycl/accessor.hpp
@@ -596,7 +596,7 @@ accessMode == access::mode::discard_read_write) && dimensions == 1) */
   HIPSYCL_UNIVERSAL_TARGET
   operator atomic<dataT, access::address_space::global_space> () const
   {
-      return atomic<dataT, access::address_space::global_space> { global_ptr<dataT>(_ptr) };
+    return atomic<dataT, access::address_space::global_space> { global_ptr<dataT>(_ptr) };
   }
 
   /* Available only when: accessMode == access::mode::atomic && dimensions > 0*/
@@ -607,7 +607,8 @@ accessMode == access::mode::discard_read_write) && dimensions == 1) */
   atomic<dataT, access::address_space::global_space> operator[](
       id<dimensions> index) const
   {
-      return atomic<dataT, access::address_space::global_space> { global_ptr<dataT>(_ptr + detail::linear_id<dimensions>::get(index, _buffer_range)) };
+    return atomic<dataT, access::address_space::global_space>
+             { global_ptr<dataT>(_ptr + detail::linear_id<dimensions>::get(index, _buffer_range)) };
   }
 
   template<int D = dimensions,
@@ -616,7 +617,7 @@ accessMode == access::mode::discard_read_write) && dimensions == 1) */
   HIPSYCL_UNIVERSAL_TARGET
   atomic<dataT, access::address_space::global_space> operator[](size_t index) const
   {
-      return atomic<dataT, access::address_space::global_space> { global_ptr<dataT>(_ptr + index) };
+    return atomic<dataT, access::address_space::global_space> { global_ptr<dataT>(_ptr + index) };
   }
 
   /* Available only when: dimensions > 1 */

--- a/include/CL/sycl/accessor.hpp
+++ b/include/CL/sycl/accessor.hpp
@@ -599,10 +599,10 @@ accessMode == access::mode::discard_read_write) && dimensions == 1) */
     return atomic<dataT, access::address_space::global_space> { global_ptr<dataT>(_ptr) };
   }
 
-  /* Available only when: accessMode == access::mode::atomic && dimensions > 0*/
+  /* Available only when: accessMode == access::mode::atomic && dimensions > 1*/
   template<int D = dimensions,
            access::mode M = accessmode,
-           typename = std::enable_if_t<(D > 0) && (M == access::mode::atomic)>>
+           typename = std::enable_if_t<(D > 1) && (M == access::mode::atomic)>>
   HIPSYCL_UNIVERSAL_TARGET
   atomic<dataT, access::address_space::global_space> operator[](
       id<dimensions> index) const
@@ -613,7 +613,7 @@ accessMode == access::mode::discard_read_write) && dimensions == 1) */
 
   template<int D = dimensions,
            access::mode M = accessmode,
-           typename = std::enable_if_t<(D == 0) && (M == access::mode::atomic)>>
+           typename = std::enable_if_t<(D == 1) && (M == access::mode::atomic)>>
   HIPSYCL_UNIVERSAL_TARGET
   atomic<dataT, access::address_space::global_space> operator[](size_t index) const
   {

--- a/include/CL/sycl/accessor.hpp
+++ b/include/CL/sycl/accessor.hpp
@@ -599,10 +599,10 @@ accessMode == access::mode::discard_read_write) && dimensions == 1) */
     return atomic<dataT, access::address_space::global_space> { global_ptr<dataT>(_ptr) };
   }
 
-  /* Available only when: accessMode == access::mode::atomic && dimensions > 1*/
+  /* Available only when: accessMode == access::mode::atomic && dimensions > 0*/
   template<int D = dimensions,
            access::mode M = accessmode,
-           typename = std::enable_if_t<(D > 1) && (M == access::mode::atomic)>>
+           typename = std::enable_if_t<(D > 0) && (M == access::mode::atomic)>>
   HIPSYCL_UNIVERSAL_TARGET
   atomic<dataT, access::address_space::global_space> operator[](
       id<dimensions> index) const

--- a/include/CL/sycl/atomic.hpp
+++ b/include/CL/sycl/atomic.hpp
@@ -25,6 +25,9 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifndef HIPSYCL_ATOMIC_HPP
+#define HIPSYCL_ATOMIC_HPP
+
 #include <type_traits>
 
 #include "access.hpp"
@@ -287,3 +290,5 @@ T atomic_fetch_max(atomic<T, addressSpace> object, T operand, memory_order memor
 
 } // namespace sycl
 } // namespace cl
+
+#endif


### PR DESCRIPTION
While I'm fixing things that are getting in my way, here's `operator[]` in atomic mode.