### PR TITLE
Silence warning in HIP headers (when using -Wall)

### DIFF
--- a/include/CL/sycl/backend/backend.hpp
+++ b/include/CL/sycl/backend/backend.hpp
@@ -48,6 +48,9 @@
   // Silence deprecation warnings in hip which occur for newer CUDA versions
   #pragma clang diagnostic push
   #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  // Required until HIP submodule is updated to include
+  // https://github.com/ROCm-Developer-Tools/HIP/pull/1497
+  #pragma clang diagnostic ignored "-Wsometimes-uninitialized"
   #include <hip/hip_runtime.h>
   #pragma clang diagnostic pop
  #elif defined(__HIP__) || defined(__HCC__)


### PR DESCRIPTION
This silences a warning emitted from HIP headers, when compiling with `-Wall`. This is only required until we update the HIP submodule to include https://github.com/ROCm-Developer-Tools/HIP/pull/1497.

Not sure if there are any breaking changes in HIP that we have to account for, also I cannot test on ROCm - otherwise I'm of course all for updating HIP :)