### PR TITLE
Warn if no optimization flag was supplied

### DIFF
--- a/bin/syclcc-clang
+++ b/bin/syclcc-clang
@@ -250,7 +250,6 @@ class syclcc_config:
         v == "false"):
       return False
     return True
-      
 
   def _is_flag_set(self, flag_name):
     flag = self._flags[flag_name]
@@ -419,7 +418,15 @@ class syclcc_config:
   
   @property
   def common_compiler_args(self):
-      return self._common_compiler_args
+    return self._common_compiler_args
+  
+  def has_optimization_flag(self):
+    for arg in self._forwarded_args:
+      if arg.startswith("-O"):
+        ending = arg.replace("-O", "", 1)
+        if ending.isnumeric() or ending in ["s", "fast", "g"]:
+          return True
+    return False
   
   def contains_linking_stage(self):
     for arg in self.forwarded_compiler_arguments:
@@ -441,7 +448,7 @@ class syclcc_config:
 
 def run_or_print(command, print_only):
   if not print_only:
-      return subprocess.call(command)
+    return subprocess.call(command)
   else:
     print(' '.join(command))
     return 0
@@ -603,6 +610,12 @@ if __name__ == '__main__':
         sys.exit(0)
 
     platform = config.target_platform
+    if not config.is_pure_linking_stage():
+      if not config.has_optimization_flag():
+        print("syclcc warning: No optimization flag was given, optimizations are "
+              "disabled by default. Performance may be degraded. Compile with e.g. -O2/-O3 to "
+              "enable optimizations.")
+
     if platform == hipsycl_platform.CUDA or platform == hipsycl_platform.HIP:
       compiler = clang_plugin_compiler(config)
       sys.exit(compiler.run())


### PR DESCRIPTION
It seems that people (especially when coming from CUDA/nvcc) occasionally trip over the fact that `syclcc` behaves like a regular C++ compiler that requires explicit `-O` flags to enable optimizations. `nvcc` or `hipcc` on the other hand optimize by default.
To avoid people getting a bad impression of (hip)SYCL performance, this adds a warning that is printed when no optimization flag is given, mentioning that performance may be suboptimal and the user should use optimization flags.