### PR TITLE
Silence -Wunused-result warnings on ROCm

### DIFF
--- a/include/hipSYCL/sycl/backend/backend.hpp
+++ b/include/hipSYCL/sycl/backend/backend.hpp
@@ -55,7 +55,10 @@
   #pragma clang diagnostic pop
  #elif defined(__HIP__) || defined(__HCC__)
   #define HIPSYCL_PLATFORM_HCC
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wunused-result"
   #include <hip/hip_runtime.h>
+  #pragma clang diagnostic pop
  #else
   #define HIPSYCL_PLATFORM_CPU
   #include "hipCPU/hip/hip_runtime.h"

--- a/include/hipSYCL/sycl/backend/clang.hpp
+++ b/include/hipSYCL/sycl/backend/clang.hpp
@@ -28,6 +28,8 @@
 #ifndef HIPSYCL_BACKEND_CLANG_HPP
 #define HIPSYCL_BACKEND_CLANG_HPP
 
+#include <cassert>
+
 #if (defined(__clang__) && defined(__HIP__)) || (defined(__clang__) && defined(__CUDA__))
 
 #define __sycl_kernel __attribute__((diagnose_if(false,"hipsycl_kernel","warning"))) 
@@ -54,7 +56,8 @@ static inline void __hipsycl_push_kernel_call(dim3 grid, dim3 block, size_t shar
 #ifdef __CUDA__
   __cudaPushCallConfiguration(grid, block, shared, stream);
 #else
-  hipConfigureCall(grid, block, shared, stream);
+  hipError_t err = hipConfigureCall(grid, block, shared, stream);
+  assert(err == hipSuccess);
 #endif
 }
 

--- a/src/sycl/application.cpp
+++ b/src/sycl/application.cpp
@@ -28,6 +28,7 @@
 #include "hipSYCL/sycl/detail/application.hpp"
 #include "hipSYCL/sycl/backend/backend.hpp"
 #include "hipSYCL/sycl/device.hpp"
+#include "hipSYCL/sycl/exception.hpp"
 
 namespace hipsycl {
 namespace sycl {
@@ -51,7 +52,7 @@ void application::reset()
   const auto devices = device::get_devices(info::device_type::all);
   for(auto& d : devices) {
     detail::set_device(d);
-    hipDeviceReset();
+    detail::check_error(hipDeviceReset());
   }
 #endif
 }

--- a/src/sycl/buffer.cpp
+++ b/src/sycl/buffer.cpp
@@ -194,12 +194,12 @@ buffer_impl::~buffer_impl()
   }
   else
   {
-    hipFree(_buffer_pointer);
+    detail::check_error(hipFree(_buffer_pointer));
 
     if(_owns_host_memory)
     {
       if(_pinned_memory)
-        hipHostFree(_host_memory);
+        detail::check_error(hipHostFree(_host_memory));
       else
         delete [] reinterpret_cast<max_aligned_vector*>(_host_memory);
     }

--- a/src/sycl/queue.cpp
+++ b/src/sycl/queue.cpp
@@ -62,7 +62,7 @@ stream_manager::~stream_manager()
 {
   if(_stream != 0)
   {
-    hipStreamDestroy(_stream);
+    detail::check_error(hipStreamDestroy(_stream));
   }
 }
 


### PR DESCRIPTION
Addresses issue #221 - hopefully silences all `-Wunused-result` warnings on ROCm.