### PR TITLE
Fix data races in hipsycl::sycl::detail::worker_thread

### DIFF
--- a/include/hipSYCL/sycl/detail/async_worker.hpp
+++ b/include/hipSYCL/sycl/detail/async_worker.hpp
@@ -78,7 +78,7 @@ private:
 
   std::thread _worker_thread;
 
-  bool _continue;
+  std::atomic<bool> _continue;
 
   std::condition_variable _condition_wait;
   mutable std::mutex _mutex;

--- a/src/sycl/async_worker.cpp
+++ b/src/sycl/async_worker.cpp
@@ -79,10 +79,14 @@ void worker_thread::work()
   // The loop is executed as long as there are enqueued operations,
   // (_is_operation_pending) or we should wait for new operations
   // (_continue).
-  while(_continue || _enqueued_operations.size() > 0)
+  while(true)
   {
     {
       std::unique_lock<std::mutex> lock(_mutex);
+
+      // enclosing loop termination must be checked while holding
+      // a lock on _enqueued_operations (_continue is std::atomic<bool>)
+      if(!_continue && _enqueued_operations.size() <= 0) break;
 
       // Before going to sleep, wake up the other thread in case it is is waiting
       // for the queue to get empty


### PR DESCRIPTION
This PR fixes several data races detected by `TSAN` while using `hipSYCL`. Each commit addresses a specific data race while all of them boil down to unsynced accesses to both `worker_thread::_continue` and `worker_thread::_enqueued_operations` (for example, full `TSAN` log of the race fixed by 4b6521bd6b0780a3d8a98c6fc925180becfdbce6 is [here](https://gist.github.com/nazavode/d3ace5286ce043a22dfed145ff963007)).

Please note that similar issues on `hipCPU` have been fixed in illuhad/hipCPU#3, both `hipSYCL` (CPU backend only, unfortunately I have no chance to test other backends right now) and `hipCPU` should be `TSAN`-clean now.

Edit: in order to have a clean `TSAN` run using `libc++` from `clang-10.0`, `llvm` must be built with `-DLIBOMP_TSAN_SUPPORT=ON` and some false positives (I hope so) should be suppressed with:

```console
$ cat hipsycl-tsan-suppressions.txt
# Setting width on a stream is not thread-safe, but logging ops do it.
# The rule must match both 'std::ios_base::width' and libc++ versioned std
# namespaces like 'std::__1::ios_base::width'.
race:std::*ios_base::width
$ export TSAN_OPTIONS='ignore_noninstrumented_modules=1 suppressions=hipsycl-tsan-suppressions.txt'
```