### PR TITLE
Add HIPSYCL_PLATFORM_ROCM macro

### DIFF
--- a/doc/macros.md
+++ b/doc/macros.md
@@ -5,7 +5,7 @@ Most of these are managed by `detail/backend/backend.hpp`.
 
 * `__HIPSYCL__` - defined if compiling with hipSYCL
 * `HIPSYCL_PLATFORM_CUDA` - defined if compiling for CUDA
-* `HIPSYCL_PLATFORM_HCC` - defined if compiling for ROCm
+* `HIPSYCL_PLATFORM_HCC` (**deprecated**) - defined if compiling for ROCm
 * `HIPSYCL_PLATFORM_ROCM` - defined if compiling for ROCm
 * `HIPSYCL_PLATFORM_CPU` - defined if compiling purely for CPU
 * `__HIPSYCL_DEVICE__` - defined if generating code for GPU

--- a/doc/macros.md
+++ b/doc/macros.md
@@ -6,6 +6,7 @@ Most of these are managed by `detail/backend/backend.hpp`.
 * `__HIPSYCL__` - defined if compiling with hipSYCL
 * `HIPSYCL_PLATFORM_CUDA` - defined if compiling for CUDA
 * `HIPSYCL_PLATFORM_HCC` - defined if compiling for ROCm
+* `HIPSYCL_PLATFORM_ROCM` - defined if compiling for ROCm
 * `HIPSYCL_PLATFORM_CPU` - defined if compiling purely for CPU
 * `__HIPSYCL_DEVICE__` - defined if generating code for GPU
 * `SYCL_DEVICE_ONLY` - defined if generating code for GPU

--- a/include/hipSYCL/sycl/backend/backend.hpp
+++ b/include/hipSYCL/sycl/backend/backend.hpp
@@ -55,6 +55,7 @@
   #pragma clang diagnostic pop
  #elif defined(__HIP__) || defined(__HCC__)
   #define HIPSYCL_PLATFORM_HCC
+  #define HIPSYCL_PLATFORM_ROCM
   #pragma clang diagnostic push
   #pragma clang diagnostic ignored "-Wunused-result"
   #include <hip/hip_runtime.h>


### PR DESCRIPTION
define `HIPSYCL_PLATFORM_ROCM` when compiling for ROCm. This allows us to deprecate `HIPSYCL_PLATFORM_HCC` in the future since hcc itself is deprecated (any not supported anymore by hipSYCL anyway)