### PR TITLE
Add custom link line for CPU platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,7 @@ add_subdirectory(src)
 
 set(DEFAULT_GPU_ARCH "" CACHE STRING "Optional: Default GPU architecture to compile for when targeting GPUs (e.g.: sm_60 or gfx900)")
 
+set(CPU_LINK_LINE "" CACHE STRING "Arguments passed to compiler to link CPU backend libraries to SYCL applications")
 set(ROCM_LINK_LINE "-rpath $HIPSYCL_ROCM_LIB_PATH -L$HIPSYCL_ROCM_LIB_PATH -lhip_hcc -lamd_comgr -lhsa-runtime64 -rpath $HIPSYCL_ROCM_PATH/hcc/lib -L$HIPSYCL_ROCM_PATH/hcc/lib -lmcwamp -lhc_am" CACHE STRING "Arguments passed to compiler to link ROCm libraries to SYCL applications")
 set(CUDA_LINK_LINE "-rpath $HIPSYCL_CUDA_LIB_PATH -L$HIPSYCL_CUDA_LIB_PATH -lcudart" CACHE STRING "Arguments passed to compiler to link CUDA libraries to SYCL applications")
 
@@ -159,6 +160,7 @@ set(SYCLCC_CONFIG_FILE "{
   \"default-use-bootstrap-mode\" : \"false\",
   \"default-is-dryrun\" : \"false\",
   \"default-clang-include-path\" : \"${CLANG_INCLUDE_PATH}\",
+  \"default-cpu-link-line\" : \"${CPU_LINK_LINE}\",
   \"default-rocm-link-line\" : \"${ROCM_LINK_LINE}\",
   \"default-cuda-link-line\" : \"${CUDA_LINK_LINE}\"
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+set(SYCLCC_BOOTSTRAP_CONFIG_FILE_PATH "${PROJECT_BINARY_DIR}/syclcc-bootstrap.json")
 set(SYCLCC_CONFIG_FILE_PATH "${PROJECT_BINARY_DIR}/syclcc.json")
 set(SYCLCC_CONFIG_FILE_GLOBAL_INSTALLATION false CACHE BOOL 
   "Whether to install the syclcc configuration file into a global directory (typically, /etc/hipSYCL). This is generally not recommended.")
@@ -149,24 +150,32 @@ set(CPU_LINK_LINE "" CACHE STRING "Arguments passed to compiler to link CPU back
 set(ROCM_LINK_LINE "-rpath $HIPSYCL_ROCM_LIB_PATH -L$HIPSYCL_ROCM_LIB_PATH -lhip_hcc -lamd_comgr -lhsa-runtime64 -rpath $HIPSYCL_ROCM_PATH/hcc/lib -L$HIPSYCL_ROCM_PATH/hcc/lib -lmcwamp -lhc_am" CACHE STRING "Arguments passed to compiler to link ROCm libraries to SYCL applications")
 set(CUDA_LINK_LINE "-rpath $HIPSYCL_CUDA_LIB_PATH -L$HIPSYCL_CUDA_LIB_PATH -lcudart" CACHE STRING "Arguments passed to compiler to link CUDA libraries to SYCL applications")
 
-
-set(SYCLCC_CONFIG_FILE "{
-  \"default-clang\"     : \"${CLANG_EXECUTABLE_PATH}\",
-  \"default-platform\"  : \"${DEFAULT_PLATFORM}\",
-  \"default-cuda-path\" : \"${CUDA_TOOLKIT_ROOT_DIR}\",
-  \"default-gpu-arch\"  : \"${DEFAULT_GPU_ARCH}\",
-  \"default-cpu-cxx\"   : \"${CMAKE_CXX_COMPILER}\",
-  \"default-rocm-path\" : \"${ROCM_PATH}\",
+set(SYCLCC_CONFIG_FILE_TEMPLATE "{
+  \"default-clang\"     : \"@CLANG_EXECUTABLE_PATH@\",
+  \"default-platform\"  : \"@DEFAULT_PLATFORM@\",
+  \"default-cuda-path\" : \"@CUDA_TOOLKIT_ROOT_DIR@\",
+  \"default-gpu-arch\"  : \"@DEFAULT_GPU_ARCH@\",
+  \"default-cpu-cxx\"   : \"@CMAKE_CXX_COMPILER@\",
+  \"default-rocm-path\" : \"@ROCM_PATH@\",
   \"default-use-bootstrap-mode\" : \"false\",
   \"default-is-dryrun\" : \"false\",
-  \"default-clang-include-path\" : \"${CLANG_INCLUDE_PATH}\",
-  \"default-cpu-link-line\" : \"${CPU_LINK_LINE}\",
-  \"default-rocm-link-line\" : \"${ROCM_LINK_LINE}\",
-  \"default-cuda-link-line\" : \"${CUDA_LINK_LINE}\"
+  \"default-clang-include-path\" : \"@CLANG_INCLUDE_PATH@\",
+  \"default-cpu-link-line\" : \"@HIPSYCL_CPU_LINK_LINE@ @CPU_LINK_LINE@\",
+  \"default-rocm-link-line\" : \"@HIPSYCL_ROCM_LINK_LINE@ @ROCM_LINK_LINE@\",
+  \"default-cuda-link-line\" : \"@HIPSYCL_CUDA_LINK_LINE@ @CUDA_LINK_LINE@\"
 }
 ")
 
-file(WRITE ${SYCLCC_CONFIG_FILE_PATH} ${SYCLCC_CONFIG_FILE})
+# 1. bootstrap config file, to be used during hipSYCL build only
+string(CONFIGURE ${SYCLCC_CONFIG_FILE_TEMPLATE} SYCLCC_CONFIG_FILE_CONTENT @ONLY)
+file(WRITE ${SYCLCC_BOOTSTRAP_CONFIG_FILE_PATH} ${SYCLCC_CONFIG_FILE_CONTENT})
+# 2. production config file, to be used in deployment only
+set(HIPSYCL_COMMON_LINK_LINE "-rpath \$HIPSYCL_LIB_PATH -L \$HIPSYCL_LIB_PATH")
+set(HIPSYCL_CPU_LINK_LINE "${HIPSYCL_COMMON_LINK_LINE} -lhipSYCL_cpu")
+set(HIPSYCL_ROCM_LINK_LINE "${HIPSYCL_COMMON_LINK_LINE} -lhipSYCL_rocm")
+set(HIPSYCL_CUDA_LINK_LINE "${HIPSYCL_COMMON_LINK_LINE} -lhipSYCL_cuda")
+string(CONFIGURE ${SYCLCC_CONFIG_FILE_TEMPLATE} SYCLCC_CONFIG_FILE_CONTENT @ONLY)
+file(WRITE ${SYCLCC_CONFIG_FILE_PATH} ${SYCLCC_CONFIG_FILE_CONTENT})
 
 install(DIRECTORY include/CL DESTINATION include/ FILES_MATCHING PATTERN "*.hpp")
 install(DIRECTORY include/SYCL DESTINATION include/ FILES_MATCHING PATTERN "*.hpp")

--- a/bin/syclcc-clang
+++ b/bin/syclcc-clang
@@ -491,11 +491,6 @@ class clang_plugin_compiler:
       self._compiler_args = []
       # In non-bootstrap mode, automatically link hipSYCL
       if not config.is_bootstrap:
-        self._linker_args += [
-          "-rpath", hipsycl_library_path,
-          "-L"+hipsycl_library_path,
-          "-lhipSYCL_cuda"
-        ]
         self._compiler_args += [
           # Use the bundled HIP installation
           "-I" + os.path.join(config.hipsycl_installation_path, "include/hipSYCL/contrib")
@@ -509,16 +504,7 @@ class clang_plugin_compiler:
       self._target = "hip"
       
       self._linker_args = config.rocm_link_line
-
-      # In non-bootstrap mode, automatically link hipSYCL
-      if not config.is_bootstrap:
-        self._linker_args += [
-          "-rpath", hipsycl_library_path,
-          "-L"+hipsycl_library_path,
-          "-lhipSYCL_rocm"
-        ]
-      
-      
+            
       self._compiler_args = [
         "-x", "hip",
         "--cuda-gpu-arch=" + config.target_arch,
@@ -572,20 +558,11 @@ class pure_cpu_compiler:
     except:
       # if not, fall back to clang
       self._compiler = config.clang_path
-      
-    hipsycl_library_path = os.path.join(config.hipsycl_installation_path,"lib/")
-
+    
     self._linker_args = config.cpu_link_line
     self._compiler_args = ["-fopenmp"]
     self._compiler_args += config.common_compiler_args
     if not config.is_bootstrap:
-      self._linker_args += [
-        "-L"+hipsycl_library_path,
-        "-lhipSYCL_cpu"
-      ]
-      if "clang" in os.path.basename(self._compiler):
-        self._linker_args += ["-rpath",hipsycl_library_path]
-
       self._compiler_args += [
         "-I" + os.path.join(config.hipsycl_installation_path, "include/"),
         "-I" + os.path.join(config.hipsycl_installation_path, "include/hipSYCL/contrib")

--- a/bin/syclcc-clang
+++ b/bin/syclcc-clang
@@ -275,7 +275,10 @@ class syclcc_config:
     ))
 
   def _get_cpu_substitution_vars(self):
-    return {}
+    return {
+      'HIPSYCL_PATH' : self.hipsycl_installation_path,
+      'HIPSYCL_LIB_PATH' : os.path.join(self.hipsycl_installation_path, "lib")
+    }
 
   def _get_rocm_substitution_vars(self):
     return {

--- a/bin/syclcc-clang
+++ b/bin/syclcc-clang
@@ -157,6 +157,9 @@ class syclcc_config:
       'clang-include-path' : option("--hipsycl-clang-include-path", "HIPSYCL_CLANG_INCLUDE_PATH", "default-clang-include-path",
 """  The path to clang's internal include headers. Typically of the form $PREFIX/include/clang/<version>/include. Only required by ROCm."""),
 
+      'cpu-link-line' : option("--hipsycl-cpu-link-line", "HIPSYCL_CPU_LINK_LINE", "default-cpu-link-line",
+""" The arguments passed to the compiler to link with CPU backend libraries."""),
+
       'rocm-link-line' : option("--hipsycl-rocm-link-line", "HIPSYCL_ROCM_LINK_LINE", "default-rocm-link-line",
 """ The arguments passed to the compiler to link with ROCm libraries."""),
       
@@ -271,6 +274,9 @@ class syclcc_config:
         flag.commandline, flag.environment
     ))
 
+  def _get_cpu_substitution_vars(self):
+    return {}
+
   def _get_rocm_substitution_vars(self):
     return {
       'HIPSYCL_ROCM_PATH' : self.rocm_path,
@@ -291,10 +297,14 @@ class syclcc_config:
     template = string.Template(template_string)
     return template.substitute(substitution_dict)
 
+  def _substitute_cpu_template_string(self, template_string):
+    return self._substitute_template_string(
+      template_string, self._get_cpu_substitution_vars())
+
   def _substitute_rocm_template_string(self, template_string):
     return self._substitute_template_string(
       template_string, self._get_rocm_substitution_vars())
-      
+
   def _substitute_cuda_template_string(self, template_string):
     return self._substitute_template_string(
       template_string, self._get_cuda_substitution_vars())
@@ -392,6 +402,11 @@ class syclcc_config:
   def hipsycl_installation_path(self):
     syclcc_path = os.path.dirname(os.path.realpath(__file__))
     return os.path.join(syclcc_path, "..")
+
+  @property
+  def cpu_link_line(self):
+    components = self._retrieve_option("cpu-link-line").split(' ')
+    return [self._substitute_cpu_template_string(arg) for arg in components]
 
   @property
   def rocm_link_line(self):
@@ -557,7 +572,7 @@ class pure_cpu_compiler:
       
     hipsycl_library_path = os.path.join(config.hipsycl_installation_path,"lib/")
 
-    self._linker_args = []
+    self._linker_args = config.cpu_link_line
     self._compiler_args = ["-fopenmp"]
     self._compiler_args += config.common_compiler_args
     if not config.is_bootstrap:

--- a/src/sycl/CMakeLists.txt
+++ b/src/sycl/CMakeLists.txt
@@ -20,7 +20,7 @@ set(INCLUDE_DIRS
   ${HIPSYCL_SOURCE_DIR}/include
   ${HIPSYCL_SOURCE_DIR})
 
-set(COMMON_SYCLCC_OPTIONS --hipsycl-bootstrap --hipsycl-config-file=${SYCLCC_CONFIG_FILE_PATH})
+set(COMMON_SYCLCC_OPTIONS --hipsycl-bootstrap --hipsycl-config-file=${SYCLCC_BOOTSTRAP_CONFIG_FILE_PATH})
 
 # Specify GPU architectures used when compiling libhipSYCL. 
 # They do not really matter as libhipSYCL does not


### PR DESCRIPTION
This PR adds the ability to specify custom link flags to be used when targeting the `cpu` platform in the same way it is now supported both for `cuda` and `hip`. This allows to overcome situations where the targeted `clang` needs additional link flags, e.g.: when using `brew`-ed `llvm` on macOS:

```console
$ cmake -DCPU_LINK_LINE="-L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib" ..
```