### PR TITLE
Partially implement event::get_profiling_info

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/ROCm-Developer-Tools/HIP
 [submodule "contrib/hipCPU"]
 	path = contrib/hipCPU
-	url = https://github.com/fknorr/hipCPU
+	url = https://github.com/illuhad/hipCPU

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/ROCm-Developer-Tools/HIP
 [submodule "contrib/hipCPU"]
 	path = contrib/hipCPU
-	url = https://github.com/illuhad/hipCPU
+	url = https://github.com/fknorr/hipCPU

--- a/include/hipSYCL/sycl/device.hpp
+++ b/include/hipSYCL/sycl/device.hpp
@@ -427,7 +427,7 @@ HIPSYCL_SPECIALIZE_GET_INFO(device, execution_capabilities)
 }
 
 HIPSYCL_SPECIALIZE_GET_INFO(device, queue_profiling)
-{ return false; }
+{ return true; }
 
 HIPSYCL_SPECIALIZE_GET_INFO(device, built_in_kernels)
 { return vector_class<string_class>{}; }

--- a/include/hipSYCL/sycl/event.hpp
+++ b/include/hipSYCL/sycl/event.hpp
@@ -87,6 +87,11 @@ public:
   template <info::event param>
   typename info::param_traits<info::event, param>::return_type get_info() const;
 
+  /// Partially implemented, as HIP/CUDA do not expose the same event timing functionality as
+  /// OpenCL. For event_profiling::command_submit and event_profiling::command_start, this always
+  /// returns 0. For event_profiling::command_end, returns the kernel run-time in nanoseconds.
+  /// The difference between command_start and command_end should be enough for basic kernel
+  /// profiling.
   template <info::event_profiling param>
   typename info::param_traits<info::event_profiling, param>::return_type get_profiling_info() const
   {

--- a/include/hipSYCL/sycl/event.hpp
+++ b/include/hipSYCL/sycl/event.hpp
@@ -89,7 +89,9 @@ public:
 
   template <info::event_profiling param>
   typename info::param_traits<info::event_profiling, param>::return_type get_profiling_info() const
-  { throw unimplemented{"event::get_profiling_info() is unimplemented."}; }
+  {
+    return _evt->get_profiling_info<param>();
+  }
 
   bool operator ==(const event& rhs) const
   { return _evt == rhs._evt; }

--- a/include/hipSYCL/sycl/handler.hpp
+++ b/include/hipSYCL/sycl/handler.hpp
@@ -1442,26 +1442,7 @@ private:
       << task_node << " for buffer " << buff << std::endl;
   }
 
-  detail::task_graph_node_ptr submit_task(detail::task_functor f)
-  {
-    auto& task_graph = detail::application::get_task_graph();
-
-    auto graph_node =
-        task_graph.insert(f, _spawned_task_nodes, get_stream(), _handler);
-
-    // Add new node to the access log of buffers. This guarantees that
-    // subsequent buffer accesses will wait for existing tasks to complete,
-    // if necessary
-    for(const auto& buffer_access : _accessed_buffers)
-    {
-      buffer_access.buff->register_external_access(
-            graph_node,
-            buffer_access.access_mode);
-    }
-
-    _spawned_task_nodes.push_back(graph_node);
-    return graph_node;
-  }
+  detail::task_graph_node_ptr submit_task(detail::task_functor f);
 
   detail::accessor_id request_accessor_id(detail::buffer_ptr buff)
   {

--- a/include/hipSYCL/sycl/info/event.hpp
+++ b/include/hipSYCL/sycl/info/event.hpp
@@ -59,6 +59,9 @@ enum class event_profiling : int
 
 HIPSYCL_PARAM_TRAIT_RETURN_VALUE(event, event::command_execution_status, event_command_status);
 HIPSYCL_PARAM_TRAIT_RETURN_VALUE(event, event::reference_count, detail::u_int);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(event_profiling, event_profiling::command_submit, uint64_t);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(event_profiling, event_profiling::command_start, uint64_t);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(event_profiling, event_profiling::command_end, uint64_t);
 
 }
 }

--- a/include/hipSYCL/sycl/queue.hpp
+++ b/include/hipSYCL/sycl/queue.hpp
@@ -59,6 +59,14 @@ using queue_submission_hooks_ptr =
 
 }
 
+namespace property {
+namespace queue {
+
+struct enable_profiling : public detail::property
+{};
+
+}
+}
 
 class queue : public detail::property_carrying_object
 {

--- a/src/sycl/buffer.cpp
+++ b/src/sycl/buffer.cpp
@@ -283,9 +283,11 @@ void buffer_impl::perform_writeback(detail::stream_ptr stream)
 
         };
 
+        // task_graph_node does not become visible to the user, so profiling is irrelevant
         node = tg.insert(task,
                          dependencies,
                          stream,
+                         false /* enable_profiling */,
                          stream->get_error_handler());
         // Write-back is logically always a read operation since
         // it is executed at buffer destruction when the buffer cannot
@@ -471,7 +473,9 @@ buffer_impl::access_host(detail::buffer_ptr buff,
           stream->get_stream());
   };
 
-  task_graph_node_ptr node = tg.insert(task, dependencies, stream, error_handler);
+  // task_graph_node does not become visible to the user, so profiling is irrelevant
+  task_graph_node_ptr node = tg.insert(task, dependencies, stream,
+      false /* enable_profiling */, error_handler);
   buff->_dependency_manager.add_operation(node, m);
 
   return node;
@@ -496,7 +500,9 @@ buffer_impl::access_device(detail::buffer_ptr buff,
 
   };
 
-  task_graph_node_ptr node = tg.insert(task, dependencies, stream, error_handler);
+  // task_graph_node does not become visible to the user, so profiling is irrelevant
+  task_graph_node_ptr node = tg.insert(task, dependencies, stream,
+                                       false /* enable_profiling */, error_handler);
   buff->_dependency_manager.add_operation(node, m);
 
   return node;


### PR DESCRIPTION
Implements `cl::sycl::event::get_profiling_info<>()` to support basic kernel profiling. HIP/CUDA do not expose the same event timing functionality as OpenCL, so for `event_profiling::command_submit` and `event_profiling::command_start`, this always returns 0. For event_profiling::command_end, returns the kernel run-time in nanoseconds. The difference between command_start and command_end should be enough for execution time measurements.

A unit test was added and verified on both hipCPU and CUDA with sm_75 GPU.

~~`.gitmodules` was changed to pull hipSYCL from [fknorr/hipCPU](https://github.com/fknorr/hipCPU), since this change requires `hipEventElapsedTime` to be implemented on all platforms. When the pending pull request https://github.com/illuhad/hipCPU/pull/4 is merged, this file should be changed back.~~