### PR TITLE
PR to issue #243: fixed std::reinterpret_pointer_cast with older libc++ versions

### DIFF
--- a/include/hipSYCL/common/reinterpret_pointer_cast.hpp
+++ b/include/hipSYCL/common/reinterpret_pointer_cast.hpp
@@ -32,8 +32,8 @@
 #include <memory>
 
 namespace hipsycl {
-namespace sycl {
-namespace detail {
+namespace common {
+namespace shim {
 
 #ifdef _LIBCPP_VERSION
 // libc++ has std::reinterpret_pointer_cast since version 11000

--- a/include/hipSYCL/sycl/buffer.hpp
+++ b/include/hipSYCL/sycl/buffer.hpp
@@ -44,7 +44,7 @@
 #include "range.hpp"
 
 #include "detail/buffer.hpp"
-#include "detail/reinterpret_pointer_cast.hpp"
+#include "../common/reinterpret_pointer_cast.hpp"
 
 #include "accessor.hpp"
 
@@ -363,8 +363,8 @@ private:
     detail::property_carrying_object::operator=(other);
     this->_alloc = other._alloc;
     this->_range = other._range;
-    this->_writeback_buffer = detail::reinterpret_pointer_cast<T>(other._writeback_buffer);
-    this->_shared_host_data = detail::reinterpret_pointer_cast<T>(other._shared_host_data);
+    this->_writeback_buffer = ::hipsycl::common::shim::reinterpret_pointer_cast<T>(other._writeback_buffer);
+    this->_shared_host_data = ::hipsycl::common::shim::reinterpret_pointer_cast<T>(other._shared_host_data);
     this->_cleanup_trigger = other._cleanup_trigger;
     this->_buffer = other._buffer;
   }

--- a/include/hipSYCL/sycl/buffer.hpp
+++ b/include/hipSYCL/sycl/buffer.hpp
@@ -44,6 +44,7 @@
 #include "range.hpp"
 
 #include "detail/buffer.hpp"
+#include "detail/reinterpret_pointer_cast.hpp"
 
 #include "accessor.hpp"
 
@@ -362,8 +363,8 @@ private:
     detail::property_carrying_object::operator=(other);
     this->_alloc = other._alloc;
     this->_range = other._range;
-    this->_writeback_buffer = std::reinterpret_pointer_cast<T>(other._writeback_buffer);
-    this->_shared_host_data = std::reinterpret_pointer_cast<T>(other._shared_host_data);
+    this->_writeback_buffer = detail::reinterpret_pointer_cast<T>(other._writeback_buffer);
+    this->_shared_host_data = detail::reinterpret_pointer_cast<T>(other._shared_host_data);
     this->_cleanup_trigger = other._cleanup_trigger;
     this->_buffer = other._buffer;
   }

--- a/include/hipSYCL/sycl/detail/reinterpret_pointer_cast.hpp
+++ b/include/hipSYCL/sycl/detail/reinterpret_pointer_cast.hpp
@@ -1,0 +1,59 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2018, 2019 Aksel Alpay and contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#ifndef HIPSYCL_REINTERPRET_POINTER_CAST_HPP
+#define HIPSYCL_REINTERPRET_POINTER_CAST_HPP
+
+#include <memory>
+
+namespace hipsycl {
+namespace sycl {
+namespace detail {
+
+#ifdef _LIBCPP_VERSION
+// libc++ has std::reinterpret_pointer_cast since version 11000
+#if _LIBCPP_VERSION < 11000
+template< class T, class U > 
+std::shared_ptr<T> reinterpret_pointer_cast(const std::shared_ptr<U>& r) noexcept {
+    auto p = reinterpret_cast<typename std::shared_ptr<T>::element_type*>(r.get());
+    return std::shared_ptr<T>(r, p);
+}
+#else
+using std::reinterpret_pointer_cast;
+#endif
+#else
+// libstdc++ has std::reinterpret_pointer_cast in c++17 mode
+using std::reinterpret_pointer_cast;
+#endif
+
+}
+}
+}
+
+#endif
+


### PR DESCRIPTION
Currently `buffer.hpp` file uses `std::reinterpret_pointer_cast`. This works with `libstdc++` in C++17 mode.
However it doesn't work with `libc++` prior to the current llvm master branch.

So I added an additional header (`detail/reinterpret_pointer_cast.hpp`) which checks if `libc++` is used via the `_LIBCPP_VERSION` macro (which is not set in `libstdc++`). If the value of this macro is less than `11000` (the value set in the current master branch, clang 10.0.0 sets the value to `10000`), the header file defines the `reinterpret_pointer_cast` function as shown on [cppreference](https://en.cppreference.com/w/cpp/memory/shared_ptr/pointer_cast). Otherwise it uses the std implementation.

After including the newly added header, we only have to change the lines in `buffer.hpp` from using `std::reinterpret_pointer_cast` to `detail::reinterpret_pointer_cast`.