### PR TITLE
Initial implementation of scoped parallelism & sub_group class

### DIFF
--- a/doc/extensions.md
+++ b/doc/extensions.md
@@ -105,3 +105,9 @@ The following 'finalizers' are supported:
 * `cl::sycl::vendor::hipsycl::synchronization::local_mem_fence` - same as `mem_fence<access::fence_space::local_space>`
 * `cl::sycl::vendor::hipsycl::synchronization::global_mem_fence` - same as `mem_fence<access::fence_space::global_space>`
 * `cl::sycl::vendor::hipsycl::synchronization::global_and_local_mem_fence` - same as `mem_fence<access::fence_space::global_and_local>`
+
+
+### `HIPSYCL_EXT_SCOPED_PARALLELISM`
+This extension provides the scoped parallelism kernel invocation and programming model. This extension does not need to be enabled explicitly and is always available.
+See [scoped-parallelism.md](here) for more details.
+

--- a/doc/scoped-parallelism.md
+++ b/doc/scoped-parallelism.md
@@ -1,0 +1,236 @@
+# Scoped parallelism
+
+## Introduction
+
+Scoped parallelism provides a novel way to formulate kernels. Scoped parallelism aims at combining the advantages of hierarchical parallelism with those of classical `nd_range` parallel for kernels:
+* It is performance portable and efficiently implementable on the host device (contrary to `nd_range` parallel for);
+* It has a clear and well-defined behavior and is easy to implement and maintain (contrary to hierarchical parallelism);
+* It does not present the user with performance surprises (contrary to both hierarchical parallelism and `nd_range` parallel for on the CPU)
+
+Scoped parallelism acknowledges that an implementation may achieve better performance by employing a different degree of parallelization within a work group compared to the user-requested work group size.
+Like hierarchical parallelism, scoped parallelism kernels consist of two scopes. But, unlike hierarchical parallelism, within the outer scope the implementation-defined physical parallelism is exposed. In the inner scope, the user-provided logical parallelism is exposed.
+
+Structurally, within a work group scoped parallelism is similar to patterns found in other programming models like OpenMP, where a (by default) implementation-defined number of threads is first spawned with `#pragma omp parallel` and later on, a user-provided parallel iteration space is distributed across the physical one using `#pragma omp for`.
+Scoped parallelism works analogously: `handler::parallel()` launches a parallel kernel, and `group::distribute_for()` distributes the user-provided iteration space across the execution resources.
+
+Scoped parallelism exposes both work items to query the position in the physical and logical iteration spaces: The `physical_item` and the `logical_item`. Additionally, `sub_group` is exposed as well, providing information about the warps/wavefronts on GPUs.
+
+Because scoped parallelism enforces explicit information about where to allocate variables from the user, performance surprises as in hierarchical parallel for are prevented. In particular, simple variable declarations in the outer scope will not be allocated in local memory (as in hierarchical parallelism), but in the private memory of the physical work item which will always be efficient.
+
+## Example code
+
+```c++
+#include <SYCL/sycl.hpp>
+#include <vector>
+
+int main(){
+  
+  sycl::queue q;
+  
+  std::size_t input_size = 1024;
+  std::vector<int> input(input_size);
+  for(int i = 0; i < input.size(); ++i)
+    input[i] = i;
+  
+  sycl::buffer<int> buff{input.data(), sycl::range<1>{input_size}};
+  
+  constexpr size_t Group_size = 128;
+  q.submit([&](sycl::handler& cgh){
+    auto data_accessor = buff.get_access<sycl::access::mode::read_write>(cgh);
+    cgh.parallel<class Kernel>(sycl::range<1>{input_size / Group_size}, sycl::range<1>{Group_size}, 
+    [=](sycl::group<1> grp, sycl::physical_item<1> phys_idx){
+      // Inside the parallel scope, the degree of parallelism is implementation-defined
+      // the implementation can use whatever is most efficient for hardware/backend.
+      // In hipSYCL CPU, this would be executed by a single thread on CPU
+      // and Group_size threads on hipSYCL GPU
+      // phys_idx contains information about the position in the (implementation-defined)
+      // physical iteration space
+
+      // Local memory in parallel scope must be allocated explicitly as such
+      sycl::local_memory<int [Group_size]> scratch{grp};
+      // Same goes for private_memory, if required (here only dummy example)
+      // This will allocate memory in the private memory of the _logical_ work item.
+      // See the existing SYCL documentation on private_memory for more information.
+      sycl::private_memory<int> dummy{grp};
+      
+      // Variables not explicitly marked as either will be allocated in private
+      // memory of the _physical_ work item (see the for loop below)
+
+      // `distribute_for` distributes the logical, user-provided iteration space across the physical one. 
+      grp.distribute_for([&](sycl::sub_group sg, sycl::logical_item<1> idx){
+          scratch[idx.get_local_id(0)] = data_accessor[idx.get_global_id(0)];
+          // Can execute code for a single item of the subgroup:
+          sg.single_item([&](){
+            //...
+          });
+      }); // implicit barrier at the end by default
+
+      // Variables inside the parallel scope that are not explicitly local or private memory
+      // are allowed, if they are not modified from inside `distribute_for()` scope.
+      // The SYCL implementation will allocate those in private memory of the physical thread,
+      // so they will always be efficient. This implies that the user should not attempt to assign values
+      // per logical work item, since they are allocated per physical item.
+      for(int i = Group_size / 2; i > 0; i /= 2){
+        grp.distribute_for([&](sycl::sub_group sg, sycl::logical_item<1> idx){
+          size_t lid = idx.get_local_id(0);
+          if(lid < i)
+            scratch[lid] += scratch[lid+i];
+        });
+      }
+      
+      grp.single_item([&](){
+        data_accessor[grp.get_id(0)] = scratch[0];
+      });
+    });
+  });
+  
+  // Verify results on host
+  auto host_acc = buff.get_access<sycl::access::mode::read>();
+  
+  for(int grp = 0; grp < input_size/Group_size; ++grp){
+    int host_result = 0;
+    for(int i = grp * Group_size; i < (grp+1) * Group_size; ++i)
+      host_result += i;
+    
+    if(host_result != host_acc[grp])
+      std::cout << "Wrong result, got " << host_acc[grp * Group_size] << ", expected " << host_result << std::endl;
+  }
+}
+```
+
+## API reference
+
+### New functions in `sycl::handler`
+
+```c++
+// Spawns a new parallel region. f must have the signature 
+// void(group<dimensions>, physical_item<dimensions>)
+template <typename KernelName, typename KernelFunctionType, int dimensions>
+void handler::parallel(range<dimensions> numWorkGroups,
+                      range<dimensions> workGroupSize,
+                      KernelFunctionType f);
+```
+
+### New functions in `sycl::group`
+
+```c++
+// Distribute the execution of f across the available parallel resources.
+// f must have the signature void(sub_group, logical_item<dimensions>)
+template<typename distributeForFunctionT>
+void group::distribute_for(distributeForFunctionT f) const;
+
+// Execute f for a single item of the group. f has the signature void().
+template<class Function>
+void group::single_item(Function f);
+```
+
+## New functions in `sub_group`
+
+```c++
+// Execute f for a single item of the sub_group. f has the signature void().
+template<class F>
+void sub_group::single_item(F f);
+```
+
+## class `local_memory<T>`
+
+```c++
+// Allocates a variable of type T in local memory.
+template<class T>
+class local_memory
+{
+public:
+  using scalar_type = typename std::remove_extent<T>::type;
+
+  // Constructor
+  template<int Dim>
+  local_memory(group<Dim>&);
+
+  // Only available if T is array. Returns reference to a single 
+  // element of the array.
+  scalar_type& operator[](std::size_t index) noexcept;
+
+  // Return managed data in local memory
+  T& operator()() noexcept;
+};
+```
+
+## class `physical_item<int Dim>`
+
+```c++
+template<int Dim>
+class physical_item
+{
+public:
+  // Returns the global range of physical work items
+  sycl::range<Dim> get_global_range() const;
+
+  // Returns the global range of physical work items
+  size_t get_global_range(int dimension) const;
+
+  // Returns the global id of the physical work item
+  sycl::id<Dim> get_global_id() const;
+
+  // Returns the global id of the physical work item
+  size_t get_global_id(int dimension) const;
+
+  // Returns the global linear id of the physical work item
+  size_t get_global_linear_id() const;
+
+  // Returns the local range of physical work items
+  sycl::range<Dim> get_local_range() const;
+
+  // Returns the local range of physical work items
+  size_t get_local_range(int dimension) const;
+
+  // Returns the local id of the physical work item
+  sycl::id<Dim> get_local_id() const;
+
+  // Returns the local id of the physical work item
+  size_t get_local_id(int dimension) const;
+  
+  // Returns the local linear id of the physical work item
+  size_t get_local_linear_id() const;
+};
+
+```
+
+## class `logical_item<int Dim>`
+
+```c++
+template<int Dim>
+class logical_item
+{
+public:
+  // Returns the global range of logical work items
+  sycl::range<Dim> get_global_range() const;
+
+  // Returns the global range of logical work items
+  size_t get_global_range(int dimension) const;
+
+  // Returns the global id of the logical work item
+  sycl::id<Dim> get_global_id() const;
+
+  // Returns the global id of the logical work item
+  size_t get_global_id(int dimension) const;
+
+  // Returns the global linear id of the logical work item
+  size_t get_global_linear_id() const;
+
+  // Returns the local range of logical work items
+  sycl::range<Dim> get_local_range() const;
+
+  // Returns the local range of logical work items
+  size_t get_local_range(int dimension) const;
+
+  // Returns the local id of the logical work item
+  sycl::id<Dim> get_local_id() const;
+
+  // Returns the local id of the logical work item
+  size_t get_local_id(int dimension) const;
+  
+  // Returns the local linear id of the logical work item
+  size_t get_local_linear_id() const;
+};
+
+```

--- a/doc/scoped-parallelism.md
+++ b/doc/scoped-parallelism.md
@@ -79,7 +79,7 @@ int main(){
       }
       
       grp.single_item([&](){
-        data_accessor[grp.get_id(0)] = scratch[0];
+        data_accessor[grp.get_id(0)*Group_size] = scratch[0];
       });
     });
   });
@@ -92,7 +92,7 @@ int main(){
     for(int i = grp * Group_size; i < (grp+1) * Group_size; ++i)
       host_result += i;
     
-    if(host_result != host_acc[grp])
+    if(host_result != host_acc[grp*Group_size])
       std::cout << "Wrong result, got " << host_acc[grp * Group_size] << ", expected " << host_result << std::endl;
   }
 }

--- a/include/hipSYCL/sycl/backend/clang.hpp
+++ b/include/hipSYCL/sycl/backend/clang.hpp
@@ -32,7 +32,7 @@
 
 #if (defined(__clang__) && defined(__HIP__)) || (defined(__clang__) && defined(__CUDA__))
 
-#define __sycl_kernel __attribute__((diagnose_if(false,"hipsycl_kernel","warning"))) 
+#define __sycl_kernel __attribute__((diagnose_if(false,"hipsycl_kernel","warning")))
 
 
 // We need these calls for configuring CUDA kernel calls - on AMD there's a similar function

--- a/include/hipSYCL/sycl/handler.hpp
+++ b/include/hipSYCL/sycl/handler.hpp
@@ -206,6 +206,31 @@ void parallel_for_workgroup(Function f,
   f(this_group);
 }
 
+template<typename KernelName, class Function, int dimensions>
+__sycl_kernel 
+void parallel_region(Function f,
+                    sycl::range<dimensions> num_groups,
+                    sycl::range<dimensions> group_size)
+{
+#ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
+  group<dimensions> this_group;
+#else
+  group<dimensions> this_group{
+    get_group_id_helper<dimensions>(), 
+    get_local_size_helper<dimensions>(),
+    get_grid_size_helper<dimensions>()
+  };
+#endif
+  physical_item<dimensions> phys_idx = detail::make_sp_item(
+    get_local_id_helper<dimensions>(),
+    get_group_id_helper<dimensions>(),
+    get_local_size_helper<dimensions>(),
+    get_grid_size_helper<dimensions>()
+  );
+  
+  f(this_group, phys_idx);
+}
+
 } // device
 
 namespace host {
@@ -420,6 +445,62 @@ void parallel_for_workgroup(Function f,
   }
 }
 
+template<class Function, int dimensions>
+inline 
+void parallel_region(Function f,
+                    sycl::range<dimensions> num_groups,
+                    sycl::range<dimensions> group_size,
+                    std::size_t num_local_mem_bytes)
+{
+#ifndef HIPCPU_NO_OPENMP
+  #pragma omp parallel
+#endif
+  {
+    host_local_memory::request_from_threadprivate_pool(num_local_mem_bytes);
+
+    auto make_physical_item = [&](sycl::id<dimensions> group_id){
+      return detail::make_sp_item(sycl::id<dimensions>{},group_id,group_size, num_groups);
+    };
+
+    if constexpr(dimensions == 1){
+#ifndef HIPCPU_NO_OPENMP
+    #pragma omp for
+#endif
+      for(size_t i = 0; i < num_groups.get(0); ++i){
+        auto group_id = sycl::id<1>{i};
+        group<1> this_group{group_id, group_size, num_groups};
+        f(this_group, make_physical_item(group_id));
+      }
+
+    } else if constexpr(dimensions == 2){
+#ifndef HIPCPU_NO_OPENMP
+    #pragma omp for collapse(2)
+#endif
+      for(size_t i = 0; i < num_groups.get(0); ++i)
+        for(size_t j = 0; j < num_groups.get(1); ++j)
+        {
+          auto group_id = sycl::id<2>{i,j};
+          group<2> this_group{group_id, group_size, num_groups};
+          f(this_group, make_physical_item(group_id));
+        } 
+    } else {
+#ifndef HIPCPU_NO_OPENMP
+    #pragma omp for collapse(3)
+#endif
+      for(size_t i = 0; i < num_groups.get(0); ++i)
+        for(size_t j = 0; j < num_groups.get(1); ++j)
+          for(size_t k = 0; k < num_groups.get(2); ++k)
+          {
+            auto group_id = sycl::id<3>{i,j,k};
+            group<3> this_group{group_id, group_size, num_groups};
+            f(this_group, make_physical_item(group_id));
+          }
+
+    }    
+    host_local_memory::release();
+  }
+}
+
 #endif // HIPSYCL_PLATFORM_CPU
 } // host
 
@@ -623,6 +704,16 @@ void set_args(Ts &&... args);
                                  kernelFunc);
   }
 
+  // Scoped parallelism API
+  
+  template <typename KernelName = class _unnamed_kernel,
+            typename KernelFunctionType, int dimensions>
+  void parallel(range<dimensions> numWorkGroups,
+                range<dimensions> workGroupSize,
+                KernelFunctionType f)
+  {
+    dispatch_parallel_region<KernelName>(numWorkGroups, workGroupSize, f);
+  }
 
   /*
   void single_task(kernel syclKernel);
@@ -1085,6 +1176,51 @@ private:
                                 detail::make_kernel_launch_range<dimensions>(block),
                                 shared_mem_size, stream->get_stream(),
                                 kernelFunc, workGroupSize);
+      }
+
+
+      return detail::task_state::enqueued;
+    };
+
+    this->submit_task(kernel_launch);
+  }
+
+  template <typename KernelName, typename WorkgroupFunctionType, int dimensions>
+  __host__
+  void dispatch_parallel_region(range<dimensions> numWorkGroups,
+                                range<dimensions> workGroupSize,
+                                WorkgroupFunctionType kernelFunc)
+  {
+
+    std::size_t shared_mem_size =
+        _local_mem_allocator.get_allocation_size();
+
+    detail::stream_ptr stream = this->get_stream();
+
+    dim3 grid = range_to_dim3(numWorkGroups);
+    dim3 block = range_to_dim3(workGroupSize);
+
+    auto kernel_launch = [=]()
+        -> detail::task_state
+    {
+      stream->activate_device();
+
+#ifdef HIPSYCL_ENABLE_HOST_KERNEL_INVOCATION
+      if(stream->get_device().is_host())
+      {
+        hipLaunchSequentialKernel(detail::dispatch::host::parallel_region,
+                                  stream->get_stream(), 0,
+                                  kernelFunc, numWorkGroups, workGroupSize, 
+                                  shared_mem_size);
+      }
+      else
+#endif
+      {
+        __hipsycl_launch_kernel(detail::dispatch::device::parallel_region<KernelName>,
+                                detail::make_kernel_launch_range<dimensions>(grid),
+                                detail::make_kernel_launch_range<dimensions>(block),
+                                shared_mem_size, stream->get_stream(),
+                                kernelFunc, numWorkGroups, workGroupSize);
       }
 
 

--- a/include/hipSYCL/sycl/local_memory.hpp
+++ b/include/hipSYCL/sycl/local_memory.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
  *
- * Copyright (c) 2019 Aksel Alpay
+ * Copyright (c) 2018-2020 Aksel Alpay
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,15 +25,48 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef HIPSYCL_EXTENSIONS_HPP
-#define HIPSYCL_EXTENSIONS_HPP
+#ifndef HIPSYCL_LOCAL_MEMORY_HPP
+#define HIPSYCL_LOCAL_MEMORY_HPP
 
-#ifdef HIPSYCL_EXT_ENABLE_ALL
- #define HIPSYCL_EXT_FP_ATOMICS
-#endif
+#include <type_traits>
 
-#define HIPSYCL_EXT_AUTO_PLACEHOLDER_REQUIRE
-#define HIPSYCL_EXT_CUSTOM_PFWI_SYNCHRONIZATION
-#define HIPSYCL_EXT_SCOPED_PARALLELISM
+#include "backend/backend.hpp"
+#include "group.hpp"
+
+namespace hipsycl {
+namespace sycl {
+
+template<class T>
+class local_memory
+{
+public:
+  using scalar_type = typename std::remove_extent<T>::type;
+
+  template<int Dim>
+  HIPSYCL_KERNEL_TARGET
+  local_memory(group<Dim>&) {}
+
+  template<class t = Scalar_type, 
+          std::enable_if_t<std::is_array<T>::value>* = nullptr>
+  HIPSYCL_KERNEL_TARGET
+  scalar_type& operator[](std::size_t index) noexcept{
+    return _var[index];
+  }
+
+  HIPSYCL_KERNEL_TARGET
+  T& operator()() noexcept{
+    return _var;
+  }
+private:
+  // It is not possible to just mark this member as __shared__
+  // here (at least for HIP/CUDA), because member variables
+  // cannot be declared in local memory. The clang plugin
+  // therefore finds all declarations of type local_memory<T>
+  // and puts them in local memory.
+  T _var;
+};
+
+}
+}
 
 #endif

--- a/include/hipSYCL/sycl/local_memory.hpp
+++ b/include/hipSYCL/sycl/local_memory.hpp
@@ -46,7 +46,7 @@ public:
   HIPSYCL_KERNEL_TARGET
   local_memory(group<Dim>&) {}
 
-  template<class t = Scalar_type, 
+  template<class t = scalar_type, 
           std::enable_if_t<std::is_array<T>::value>* = nullptr>
   HIPSYCL_KERNEL_TARGET
   scalar_type& operator[](std::size_t index) noexcept{

--- a/include/hipSYCL/sycl/sp_item.hpp
+++ b/include/hipSYCL/sycl/sp_item.hpp
@@ -1,0 +1,132 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2018-2020 Aksel Alpay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef HIPSYCL_SP_ITEM_HPP
+#define HIPSYCL_SP_ITEM_HPP
+
+#include "backend/backend.hpp"
+#include "id.hpp"
+#include "range.hpp"
+#include "detail/thread_hierarchy.hpp"
+
+namespace hipsycl {
+namespace sycl {
+namespace detail {
+
+template<int Dim>
+class sp_item
+{
+  template<int D>
+  HIPSYCL_KERNEL_TARGET
+  friend sp_item<D> make_sp_item(
+    sycl::id<D> local_id, sycl::id<D> group_id,
+    sycl::range<D> local_range, sycl::range<D> num_groups);
+public:
+  HIPSYCL_KERNEL_TARGET
+  sycl::range<Dim> get_global_range() const {
+    return _num_groups * _local_range;
+  }
+
+  HIPSYCL_KERNEL_TARGET
+  size_t get_global_range(int dimension) const {
+    return _num_groups[dimension] * _local_range[dimension];
+  }
+
+  HIPSYCL_KERNEL_TARGET
+  sycl::id<Dim> get_global_id() const {
+    return _local_id + _group_id * _local_range;
+  }
+
+  HIPSYCL_KERNEL_TARGET
+  size_t get_global_id(int dimension) const {
+    return _local_id[dimension] + 
+      _group_id[dimension] * _local_range[dimension];
+  }
+
+  HIPSYCL_KERNEL_TARGET
+  size_t get_global_linear_id() const {
+    return detail::linear_id<Dim>::get(get_global_id(), get_global_range());
+  }
+
+  HIPSYCL_KERNEL_TARGET
+  sycl::range<Dim> get_local_range() const {
+    return _local_range;
+  }
+
+  HIPSYCL_KERNEL_TARGET
+  size_t get_local_range(int dimension) const {
+    return _local_range[dimension];
+  }
+
+  HIPSYCL_KERNEL_TARGET
+  sycl::id<Dim> get_local_id() const {
+    return _local_id;
+  }
+
+  HIPSYCL_KERNEL_TARGET
+  size_t get_local_id(int dimension) const {
+    return _local_id[dimension];
+  }
+
+  HIPSYCL_KERNEL_TARGET
+  size_t get_local_linear_id() const {
+    return detail::linear_id<Dim>::get(_local_id, _local_range);
+  }
+private:
+  sp_item(sycl::id<Dim> local_id, sycl::id<Dim> group_id,
+          sycl::range<Dim> local_range, sycl::range<Dim> num_groups)
+    : _local_id{local_id}, _group_id{group_id}, 
+      _local_range{local_range}, _num_groups{num_groups}
+  {}
+  
+  sycl::id<Dim> _local_id;
+  sycl::id<Dim> _group_id;
+
+  sycl::range<Dim> _local_range;
+  sycl::range<Dim> _num_groups;
+};
+
+template<int Dim>
+HIPSYCL_KERNEL_TARGET
+sp_item<Dim> make_sp_item(sycl::id<Dim> local_id, sycl::id<Dim> group_id,
+                          sycl::range<Dim> local_range, sycl::range<Dim> num_groups){
+
+  return sp_item<Dim>{local_id, group_id, local_range, num_groups};
+}
+
+}
+
+template<int Dim>
+using logical_item=detail::sp_item<Dim>;
+
+template<int Dim>
+using physical_item=detail::sp_item<Dim>;
+
+}
+}
+
+#endif

--- a/include/hipSYCL/sycl/sub_group.hpp
+++ b/include/hipSYCL/sycl/sub_group.hpp
@@ -1,0 +1,175 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2018-2020 Aksel Alpay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef HIPSYCL_SUBGROUP_HPP
+#define HIPSYCL_SUBGROUP_HPP
+
+#include "backend/backend.hpp"
+#include "id.hpp"
+#include "range.hpp"
+
+namespace hipsycl {
+namespace sycl {
+
+#ifdef SYCL_DEVICE_ONLY
+class sub_group
+{
+public:
+  using id_type = sycl::id<1>;
+  using range_type = sycl::range<1>;
+  using linear_id_type = std::size_t;
+  static constexpr int dimensions = 1;
+
+  HIPSYCL_KERNEL_TARGET
+  id_type get_local_id() const {
+    return id_type{get_local_linear_id()};
+  }
+
+  HIPSYCL_KERNEL_TARGET
+  linear_id_type get_local_linear_id() const {
+    return local_tid() & get_warp_mask();
+  }
+
+  HIPSYCL_KERNEL_TARGET
+  range_type get_local_range() const {
+    return warpSize;
+  }
+
+  HIPSYCL_KERNEL_TARGET
+  range_type get_max_local_range() const {
+    return get_local_range();
+  }
+
+  HIPSYCL_KERNEL_TARGET
+  id_type get_group_id() const {
+    return id_type{get_group_linear_id()};
+  }
+
+  HIPSYCL_KERNEL_TARGET
+  linear_id_type get_group_linear_id() const {
+    // Assumes warpSize is power of two
+    return local_tid() >> __ffs(warpSize);
+  }
+
+  HIPSYCL_KERNEL_TARGET
+  range_type get_group_range() const {
+    int local_range = hipBlockDim_x * hipBlockDim_y * hipBlockDim_z;
+    return (local_range + warpSize - 1)/ warpSize;
+  }
+
+  HIPSYCL_KERNEL_TARGET
+  range_type get_max_group_range() const {
+    return get_group_range();
+  }
+
+  template<class F>
+  HIPSYCL_KERNEL_TARGET
+  void single_item(F f){
+    if(get_local_id() == 0) f();
+  }
+private:
+  HIPSYCL_KERNEL_TARGET
+  int local_tid() const {
+    int tid = hipThreadIdx_x 
+            + hipThreadIdx_y * hipBlockDim_x 
+            + hipThreadIdx_z * hipBlockDim_x * hipBlockDim_y;
+    return tid;
+  }
+
+  HIPSYCL_KERNEL_TARGET
+  int get_warp_mask() const {
+    // Assumes that warpSize is a power of two
+    return warpSize - 1;
+  }
+};
+
+#else
+
+class sub_group
+{
+public:
+  using id_type = sycl::id<1>;
+  using range_type = sycl::range<1>;
+  using linear_id_type = std::size_t;
+  static constexpr int dimensions = 1;
+
+  HIPSYCL_KERNEL_TARGET
+  id_type get_local_id() const {
+    return id_type{0};
+  }
+
+  HIPSYCL_KERNEL_TARGET
+  linear_id_type get_local_linear_id() const {
+    return 0;
+  }
+
+  HIPSYCL_KERNEL_TARGET
+  range_type get_local_range() const {
+    return range_type{1};
+  }
+
+  HIPSYCL_KERNEL_TARGET
+  range_type get_max_local_range() const {
+    return range_type{1};
+  }
+
+  HIPSYCL_KERNEL_TARGET
+  id_type get_group_id() const {
+    return id_type{_item_linear_id};
+  }
+
+  HIPSYCL_KERNEL_TARGET
+  linear_id_type get_group_linear_id() const {
+    return _item_linear_id;
+  }
+
+  HIPSYCL_KERNEL_TARGET
+  range_type get_group_range() const {
+    return _group_size;
+  }
+
+  HIPSYCL_KERNEL_TARGET
+  range_type get_max_group_range() const {
+    return _group_size;
+  }
+
+  template<class F>
+  HIPSYCL_KERNEL_TARGET
+  void single_item(F f){
+    f();
+  }
+
+private:
+  std::size_t _item_linear_id;
+  std::size_t _group_size;
+};
+#endif
+
+}
+}
+
+#endif

--- a/include/hipSYCL/sycl/sycl.hpp
+++ b/include/hipSYCL/sycl/sycl.hpp
@@ -49,7 +49,9 @@
 #include "multi_ptr.hpp"
 #include "group.hpp"
 #include "h_item.hpp"
+#include "sp_item.hpp"
 #include "private_memory.hpp"
+#include "local_memory.hpp"
 #include "vec.hpp"
 #include "builtin.hpp"
 #include "math.hpp"
@@ -59,6 +61,7 @@
 #include "program.hpp"
 #include "kernel.hpp"
 #include "stream.hpp"
+#include "sub_group.hpp"
 
 #endif
 

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -1241,5 +1241,56 @@ BOOST_AUTO_TEST_CASE(custom_pfwi_synchronization_extension) {
   }
 }
 #endif
+#ifdef HIPSYCL_EXT_SCOPED_PARALLELISM
+BOOST_AUTO_TEST_CASE(scoped_parallelism_reduction) {
+  namespace s = cl::sycl;
+  s::queue q;
+  
+  std::size_t input_size = 256;
+  std::vector<int> input(input_size);
+  for(int i = 0; i < input.size(); ++i)
+    input[i] = i;
+  
+  s::buffer<int> buff{input.data(), s::range<1>{input_size}};
+  
+  constexpr size_t Group_size = 64;
+  
+  q.submit([&](s::handler& cgh){
+    auto data_accessor = buff.get_access<s::access::mode::read_write>(cgh);
+    cgh.parallel<class Kernel>(s::range<1>{input_size / Group_size}, s::range<1>{Group_size}, 
+    [=](s::group<1> grp, s::physical_item<1> phys_idx){
+      s::local_memory<int [Group_size]> scratch{grp};
+      
+      grp.distribute_for([&](s::sub_group sg, s::logical_item<1> idx){
+          scratch[idx.get_local_id(0)] = data_accessor[idx.get_global_id(0)];
+      });
+
+      for(int i = Group_size / 2; i > 0; i /= 2){
+        grp.distribute_for([&](s::sub_group sg, s::logical_item<1> idx){
+          size_t lid = idx.get_local_id(0);
+          if(lid < i)
+            scratch[lid] += scratch[lid+i];
+        });
+      }
+      
+      grp.single_item([&](){
+        data_accessor[grp.get_id(0)*Group_size] = scratch[0];
+      });
+    });
+  });
+  
+  auto host_acc = buff.get_access<s::access::mode::read>();
+  
+  for(int grp = 0; grp < input_size/Group_size; ++grp){
+    int host_result = 0;
+    for(int i = grp * Group_size; i < (grp+1) * Group_size; ++i)
+      host_result += i;
+    
+    BOOST_TEST(host_result == host_acc[grp * Group_size]);
+  }
+}
+
+
+#endif
 
 BOOST_AUTO_TEST_SUITE_END() // NOTE: Make sure not to add anything below this line


### PR DESCRIPTION
This adds the initial implementation of scoped parallelism. Also provides the initial implementation of the `sub_group` class from DPC++.

See https://github.com/illuhad/hipSYCL/blob/scoped-parallelism/doc/scoped-parallelism.md for more information on scoped parallelism and the API.

This is a draft pull request because this still requires additional validation and tests. Additionally, there are still some unanswered questions, in particular what the best way would be to have customizable synchronization behavior for `distribute_for` and the `single_item` functions.