### PR TITLE
Use find_package to detect syclcc in tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,14 +2,10 @@ project(hipsycl-tests)
 cmake_minimum_required(VERSION 3.5)
 
 find_package(Boost COMPONENTS unit_test_framework REQUIRED)
+find_package(hipSYCL REQUIRED)
+message(STATUS "Using hipSYCL installation in ${hipSYCL_DIR}")
 
-find_program(SYCLCC NAMES syclcc-clang CACHE STRING)
-if(SYCLCC MATCHES SYCLCC-NOTFOUND)
-  message(SEND_ERROR "hipSYCL syclcc-clang compiler not found, exiting.")
-  return()
-endif()
-
-set(CMAKE_CXX_COMPILER ${SYCLCC})
+set(CMAKE_CXX_COMPILER ${HIPSYCL_SYCLCC})
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)


### PR DESCRIPTION
Although I have a system-wide installation of hipSYCL, I still need to build and run the tests against a local installation in my home directory when verifying changes I made to hipSYCL. `tests/CMakeLists.txt` so far simply tries to find syclcc, which always returns the system version for me. Replacing this by `find_package` allows me to specify `-DhipSYCL_DIR=...`and reference the correct installation when configuring the test project.