### PR TITLE
cmake: Don't look for specific versions of LLVM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,28 +20,7 @@ FORCE)
   endif()
 endif()
 
-if(DISABLE_LLVM_VERSION_CHECK)
-  # just use whatever we are given - some llvm distributions do
-  # not correctly advertise their versions, and if users explicitly point
-  # us to them, let's assume they know what they are doing.
-  find_package(LLVM CONFIG)
-else()
-  # By default, try to find the newest supported LLVM version
-  find_package(LLVM 10 CONFIG QUIET)
-  if(NOT LLVM_FOUND)
-    message(STATUS "No suitable LLVM 10 installation found.")
-    find_package(LLVM 9 CONFIG QUIET)
-    if(NOT LLVM_FOUND)
-      message(STATUS "No suitable LLVM 9 installation found.")
-      find_package(LLVM 8 CONFIG QUIET)
-    endif()
-  endif()
-  if(NOT LLVM_FOUND)
-    message(SEND_ERROR "Could not find an LLVM installation of version 8 or newer. 
-      If you are sure to have passed a suitable LLVM path with -DLLVM_DIR, try again with 
-      -DDISABLE_LLVM_VERSION_CHECK=ON.")
-  endif()
-endif()
+find_package(LLVM CONFIG)
 message(STATUS "Building hipSYCL against LLVM configured from ${LLVM_DIR}")
 #find_package(Clang REQUIRED)
 

--- a/install/scripts/install-hipsycl.sh
+++ b/install/scripts/install-hipsycl.sh
@@ -37,7 +37,6 @@ cmake \
 -DCLANG_INCLUDE_PATH=$LLVM_INCLUDE_PATH \
 -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX \
 -DROCM_LINK_LINE='-rpath $HIPSYCL_ROCM_LIB_PATH -rpath $HIPSYCL_ROCM_PATH/hsa/lib -L$HIPSYCL_ROCM_LIB_PATH -lhip_hcc -lamd_comgr -lamd_hostcall -lhsa-runtime64 -latmi_runtime -rpath $HIPSYCL_ROCM_PATH/hcc/lib -L$HIPSYCL_ROCM_PATH/hcc/lib -lmcwamp -lhc_am' \
--DDISABLE_LLVM_VERSION_CHECK=ON \
 ..
 
 make install


### PR DESCRIPTION
Remove the old cmake behavior of by default trying to look for the newest LLVM it can find.
* cmake LLVM version detection is sometimes unreliable
* the old behavior can cause cmake to silently ignore if the user has explicitly specified `-DLLVM_DIR`
* make it easier to use hipSYCL with very new unreleased LLVM versions without us having to maintain an ever-growing list of LLVM versions in cmake.