### PR TITLE
Drop support for nd_range parallel for on CPU

### DIFF
--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_CASE(basic_parallel_for_with_offset) {
     BOOST_REQUIRE(acc[i] == (i >= offset ? i : 0));
   }
 }
-
+#ifndef HIPSYCL_PLATFORM_CPU
 BOOST_AUTO_TEST_CASE(basic_parallel_for_nd) {
   constexpr size_t num_threads = 128;
   constexpr size_t group_size = 16;
@@ -100,7 +100,7 @@ BOOST_AUTO_TEST_CASE(basic_parallel_for_nd) {
     BOOST_REQUIRE(acc[i] == i / group_size);
   }
 }
-
+#endif
 BOOST_AUTO_TEST_CASE(hierarchical_dispatch) {
   constexpr size_t local_size = 256;
   constexpr size_t global_size = 1024;
@@ -178,6 +178,7 @@ BOOST_AUTO_TEST_CASE(private_memory) {
     BOOST_TEST(host_acc[i] == i);
 }
 
+#ifndef HIPSYCL_PLATFORM_CPU
 BOOST_AUTO_TEST_CASE(dynamic_local_memory) {
   constexpr size_t local_size = 256;
   constexpr size_t global_size = 1024;
@@ -218,6 +219,7 @@ BOOST_AUTO_TEST_CASE(dynamic_local_memory) {
     BOOST_TEST(computed == expected);
   }
 }
+#endif
 
 BOOST_AUTO_TEST_CASE(placeholder_accessors) {
   using namespace cl::sycl::access;


### PR DESCRIPTION
This PR drops supports for `nd_range` parallel for on the CPU backend.

`nd_range` parallel for **cannot** be implemented efficiently as defined by the specification on pure-library implementations such as the hipSYCL CPU backend. **No user desiring performance portability should therefore ever use it anyway.**
By "not efficient" I don't mean 20% or 40% slower, I mean four orders of magnitude increase in runtime are expected. In other words, it is unusable anyway - this PR will hence only point users explicitly to the problem instead of letting them figure out the problem on their own.

Code using `nd_range` parallel for will still compile, but throw an exception at runtime.

Supporting `nd_range` on CPU means we need to support an entirely different execution model just for CPU `nd_range` which considerably complicates the implementation, especially as we start implementing SYCL 2020 features and might even make some of them impossible.

Only supporting the (superior) model of mapping one thread to an entire work group as used by hierarchical and scoped parallelism will allow us to clean up the code considerably in the future.

In the future we might reenable support for some corner cases that can be implemented without a different execution model. In particular `nd_range` parallel for with a work group size of 1 would be possible, although I doubt that this will be useful for many users.

Recommendations for users who need `nd_range` on CPU:
* please verify that you really need the features of `nd_range` parallel for. If local memory is not used, you can use basic parallel for.
* users targeting SYCL 1.2.1 may use hierarchical parallel for, which can express the same algorithms, but may have functionality caveats in hipSYCL and/or other SYCL implementations.
* if you use hipSYCL exclusively, you are encouraged to use scoped parallelism:
  https://github.com/illuhad/hipSYCL/blob/develop/doc/scoped-parallelism.md

@DieGoldeneEnte This might be interesting for you as it can greatly simplify the implementation of group algorithms on CPU :)