### PR TITLE
ROCm: Fix crashes when using dynamic local memory due to HIP clang bug

### DIFF
--- a/include/hipSYCL/sycl/detail/local_memory_allocator.hpp
+++ b/include/hipSYCL/sycl/detail/local_memory_allocator.hpp
@@ -183,8 +183,13 @@ public:
   static T* get_ptr(const address addr)
   {
 #ifdef SYCL_DEVICE_ONLY
+ #ifdef HIPSYCL_PLATFORM_CUDA
     extern __shared__ local_memory_allocator::smallest_type local_mem_data [];
     return reinterpret_cast<T*>(reinterpret_cast<char*>(local_mem_data) + addr);
+ #elif defined(HIPSYCL_PLATFORM_ROCM)
+    return reinterpret_cast<T*>(
+      reinterpret_cast<char*>(__amdgcn_get_dynamicgroupbaseptr()) + addr);
+ #endif
 #elif defined(HIPSYCL_PLATFORM_CPU) 
     return reinterpret_cast<T*>(host_local_memory::get_ptr() + addr);
 #else


### PR DESCRIPTION
It seems that HIP support in clang >= 10 generates incorrect code in certain cases when using dynamic local memory of the form `extern __shared__ T[]`. This affects local accessors in hipSYCL that use this feature.

This PR replaces the `extern __shared__` syntax on ROCm with a direct call to `__amdgcn_get_dynamicgroupbaseptr()` to obtain the dynamic local memory base pointer. This works as expected.

Note to self: Upon merging this must be cherrypicked into the `sycl/1.2.1` branch and `stable`, unless stable is updated soon anyway.