### PR TITLE
Feature/reduce default 3d group size

### DIFF
--- a/include/hipSYCL/sycl/detail/local_memory_allocator.hpp
+++ b/include/hipSYCL/sycl/detail/local_memory_allocator.hpp
@@ -183,8 +183,13 @@ public:
   static T* get_ptr(const address addr)
   {
 #ifdef SYCL_DEVICE_ONLY
+ #ifdef HIPSYCL_PLATFORM_CUDA
     extern __shared__ local_memory_allocator::smallest_type local_mem_data [];
     return reinterpret_cast<T*>(reinterpret_cast<char*>(local_mem_data) + addr);
+ #elif defined(HIPSYCL_PLATFORM_ROCM)
+    return reinterpret_cast<T*>(
+      reinterpret_cast<char*>(__amdgcn_get_dynamicgroupbaseptr()) + addr);
+ #endif
 #elif defined(HIPSYCL_PLATFORM_CPU) 
     return reinterpret_cast<T*>(host_local_memory::get_ptr() + addr);
 #else

--- a/include/hipSYCL/sycl/handler.hpp
+++ b/include/hipSYCL/sycl/handler.hpp
@@ -916,7 +916,7 @@ private:
     else if(dimensions == 2)
       return dim3(16,16);
     else if(dimensions == 3)
-      return dim3(8,8,8);
+      return dim3(4,8,8);
 
     return dim3(1);
   }


### PR DESCRIPTION
Depends on #287

Reduce default local size on ROCm as ROCm devices don't like work group sizes over 256. This fixes a GPU memory access violation in the unit tests on ROCm for the `item_api<3>` test.

Note to self: Upon merging this must be cherrypicked into the `sycl/1.2.1` branch and `stable`, unless stable is updated soon anyway.