### PR TITLE
Fix buffer/id operators, add accessor operator==

### DIFF
--- a/include/hipSYCL/sycl/accessor.hpp
+++ b/include/hipSYCL/sycl/accessor.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
  *
- * Copyright (c) 2018 Aksel Alpay
+ * Copyright (c) 2018-2020 Aksel Alpay and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -469,6 +469,18 @@ access::target::constant_buffer)) && dimensions > 0 */
 
 
   /* -- common interface members -- */
+
+  friend bool operator==(const accessor& lhs, const accessor& rhs)
+  {
+    return lhs._ptr == rhs._ptr && lhs._buffer_range == rhs._buffer_range &&
+      lhs._range == rhs._range && lhs._offset == rhs._offset;
+  }
+
+  friend bool operator!=(const accessor& lhs, const accessor& rhs)
+  {
+    return !(lhs == rhs);
+  }
+
   HIPSYCL_UNIVERSAL_TARGET
   constexpr bool is_placeholder() const
   {
@@ -750,6 +762,17 @@ public:
 
 
   /* -- common interface members -- */
+
+  friend bool operator==(const accessor& lhs, const accessor& rhs)
+  {
+    return lhs._addr == rhs._addr && lhs._num_elements == rhs._num_elements;
+  }
+
+  friend bool operator!=(const accessor& lhs, const accessor& rhs)
+  {
+    return !(lhs == rhs);
+  }
+
   HIPSYCL_KERNEL_TARGET
   size_t get_size() const
   {

--- a/include/hipSYCL/sycl/buffer.hpp
+++ b/include/hipSYCL/sycl/buffer.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
  *
- * Copyright (c) 2018 Aksel Alpay
+ * Copyright (c) 2018-2020 Aksel Alpay and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -338,7 +338,7 @@ public:
 
   friend bool operator==(const buffer& lhs, const buffer& rhs)
   {
-    return lhs->_buffer == rhs->_buffer;
+    return lhs._buffer == rhs._buffer;
   }
 
   friend bool operator!=(const buffer& lhs, const buffer& rhs)

--- a/include/hipSYCL/sycl/id.hpp
+++ b/include/hipSYCL/sycl/id.hpp
@@ -180,7 +180,7 @@ struct id {
   friend id<dimensions>& operator op(id<dimensions> &lhs, const id<dimensions> &rhs) { \
     for(std::size_t i = 0; i < dimensions; ++i) \
       lhs._data[i] op rhs._data[i]; \
-    return *lhs; \
+    return lhs; \
   }
 
   HIPSYCL_ID_BINARY_OP_IN_PLACE(+=)
@@ -199,7 +199,7 @@ struct id {
   friend id<dimensions>& operator op(id<dimensions> &lhs, const std::size_t &rhs) { \
     for(std::size_t i = 0; i < dimensions; ++i) \
       lhs._data[i] op rhs; \
-    return *lhs; \
+    return lhs; \
   }
 
   HIPSYCL_ID_BINARY_OP_IN_PLACE_SIZE_T(+=)

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -505,6 +505,54 @@ auto make_test_value(const T<1>& a, const T<2>& b, const T<3>& c) {
   return std::get<dimensions - 1>(std::make_tuple(a, b, c));
 }
 
+template <template<int D> class T, int dimensions>
+void test_id_range_operators() {
+  const auto test_value = make_test_value<T, dimensions>({ 5 }, { 5, 7 }, { 5, 7, 11 });
+  const auto other_test_value = make_test_value<T, dimensions>({ 3 }, { 3, 4 }, { 3, 4, 9 });
+
+  {
+    // T + T
+    const auto result = test_value + other_test_value;
+    if(dimensions >= 1) BOOST_TEST(result[0] == 8);
+    if(dimensions >= 2) BOOST_TEST(result[1] == 11);
+    if(dimensions == 3) BOOST_TEST(result[2] == 20);
+  }
+
+  {
+    // T + size_t
+    const auto result = test_value + 2;
+    if(dimensions >= 1) BOOST_TEST(result[0] == 7);
+    if(dimensions >= 2) BOOST_TEST(result[1] == 9);
+    if(dimensions == 3) BOOST_TEST(result[2] == 13);
+  }
+
+  {
+    // T += T
+    auto result = test_value;
+    result+= other_test_value;
+    if(dimensions >= 1) BOOST_TEST(result[0] == 8);
+    if(dimensions >= 2) BOOST_TEST(result[1] == 11);
+    if(dimensions == 3) BOOST_TEST(result[2] == 20);
+  }
+
+  {
+    // T += size_t
+    auto result = test_value;
+    result += 2;
+    if(dimensions >= 1) BOOST_TEST(result[0] == 7);
+    if(dimensions >= 2) BOOST_TEST(result[1] == 9);
+    if(dimensions == 3) BOOST_TEST(result[2] == 13);
+  }
+
+  {
+    // size_t + T
+    auto result = 2 + test_value;
+    if(dimensions >= 1) BOOST_TEST(result[0] == 7);
+    if(dimensions >= 2) BOOST_TEST(result[1] == 9);
+    if(dimensions == 3) BOOST_TEST(result[2] == 13);
+  }
+}
+
 BOOST_AUTO_TEST_CASE_TEMPLATE(range_api, _dimensions, test_dimensions::type) {
   namespace s = cl::sycl;
   constexpr auto d = _dimensions::value;
@@ -587,7 +635,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(range_api, _dimensions, test_dimensions::type) {
     BOOST_TEST(range.size() == 5 * (d >= 2 ? 7 : 1) * (d == 3 ? 11 : 1));
   }
 
-  // TODO: In-place and binary operators
+  test_id_range_operators<s::range, d>();
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(id_api, _dimensions, test_dimensions::type) {
@@ -678,7 +726,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(id_api, _dimensions, test_dimensions::type) {
     if(d == 3) BOOST_TEST(id[2] == 11);
   }
 
-  // TODO: In-place and binary operators
+  test_id_range_operators<s::id, d>();
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(item_api, _dimensions, test_dimensions::type) {

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
  *
- * Copyright (c) 2018, 2019 Aksel Alpay and contributors
+ * Copyright (c) 2018-2020 Aksel Alpay and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -324,6 +324,75 @@ BOOST_AUTO_TEST_CASE(buffer_versioning) {
       BOOST_REQUIRE(acc[i] == buf_size - i);
     }
   }
+}
+
+// TODO: Extend this
+BOOST_AUTO_TEST_CASE(buffer_api) {
+  namespace s = cl::sycl;
+
+  s::buffer<int, 1> buf_a(32);
+  s::buffer<int, 1> buf_b(32);
+  auto buf_c = buf_a;
+
+  BOOST_REQUIRE(buf_a == buf_a);
+  BOOST_REQUIRE(buf_a != buf_b);
+  BOOST_REQUIRE(buf_a == buf_c);
+}
+
+// TODO: Extend this
+BOOST_AUTO_TEST_CASE(accessor_api) {
+  namespace s = cl::sycl;
+
+  s::buffer<int, 1> buf_a(32);
+  s::buffer<int, 1> buf_b(32);
+  auto buf_c = buf_a;
+
+  const auto run_test = [&](auto get_access) {
+    auto acc_a1 = get_access(buf_a);
+    auto acc_a2 = acc_a1;
+    auto acc_a3 = get_access(buf_a, s::range<1>(16));
+    auto acc_a4 = get_access(buf_a, s::range<1>(16), s::id<1>(4));
+    auto acc_a5 = get_access(buf_a);
+    auto acc_b1 = get_access(buf_b);
+    auto acc_c1 = get_access(buf_c);
+
+    BOOST_REQUIRE(acc_a1 == acc_a1);
+    BOOST_REQUIRE(acc_a2 == acc_a2);
+    BOOST_REQUIRE(acc_a1 != acc_a3);
+    BOOST_REQUIRE(acc_a1 != acc_a4);
+    BOOST_REQUIRE(acc_a1 != acc_b1);
+    // NOTE: A strict reading of the 1.2.1 Rev 7 spec, section 4.3.2 would imply
+    // that these should not be equal, as they are not copies of acc_a1.
+    BOOST_REQUIRE(acc_a1 == acc_a5);
+    BOOST_REQUIRE(acc_a1 == acc_c1);
+  };
+
+  // Test host accessors
+  run_test([&](auto buf, auto... args) {
+    return buf.template get_access<s::access::mode::read>(args...);
+  });
+
+  // Test device accessors
+  s::queue queue;
+  queue.submit([&](s::handler& cgh) {
+    run_test([&](auto buf, auto... args) {
+      return buf.template get_access<s::access::mode::read>(cgh, args...);
+    });
+    cgh.single_task<class accessor_api_device_accessors>([](){});
+  });
+
+  // Test local accessors
+  queue.submit([&](s::handler& cgh) {
+    s::accessor<int, 1, s::access::mode::read_write, s::access::target::local> acc_a(32, cgh);
+    s::accessor<int, 1, s::access::mode::read_write, s::access::target::local> acc_b(32, cgh);
+    auto acc_c = acc_a;
+
+    BOOST_REQUIRE(acc_a == acc_a);
+    BOOST_REQUIRE(acc_a != acc_b);
+    BOOST_REQUIRE(acc_a == acc_c);
+
+    cgh.parallel_for<class accessor_api_local_accessors>(s::nd_range<1>(1, 1), [](s::nd_item<1>){});
+  });
 }
 
 BOOST_AUTO_TEST_CASE(vec_api) {


### PR DESCRIPTION
See ⬆.

As I've noted in the test for `accessor::operator==`, a strict reading of the 1.2.1 Rev 7 spec, section 4.3.2 would imply that two accessors that were independently created from the same buffer (i.e., not copied) should not be equal. As the two are however indistinguishable, I don't think there is any harm in this current behavior.