### PR TITLE
CMake: No Int Type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,11 +10,11 @@ endif()
 
 if(NOT HIPSYCL_DEBUG_LEVEL)
   if(CMAKE_BUILD_TYPE MATCHES "Debug")
-    set(HIPSYCL_DEBUG_LEVEL 3 CACHE INTEGER
+    set(HIPSYCL_DEBUG_LEVEL 3 CACHE STRING
       "Choose the debug level, options are: 0 (no debug), 1 (print errors), 2 (also print warnings), 3 (also print general information)"
 FORCE)
   else()
-    set(HIPSYCL_DEBUG_LEVEL 1 CACHE INTEGER
+    set(HIPSYCL_DEBUG_LEVEL 1 CACHE STRING
       "Choose the debug level, options are: 0 (no debug), 1 (print errors), 2 (also print warnings), 3 (also print general information)"
 FORCE)
   endif()


### PR DESCRIPTION
Fix the warning:
```
CMake Warning (dev) at CMakeLists.txt:17 (set):
  implicitly converting 'INTEGER' to 'STRING' type.
```

Ref.: https://cmake.org/cmake/help/v3.18/command/set.html