### PR TITLE
[SYCL 2020][USM] Change context,platform,queue to rely on device list from context

### DIFF
--- a/include/hipSYCL/runtime/backend.hpp
+++ b/include/hipSYCL/runtime/backend.hpp
@@ -29,6 +29,7 @@
 #define HIPSYCL_RUNTIME_BACKEND_HPP
 
 #include <memory>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
@@ -52,6 +53,8 @@ public:
   virtual backend_hardware_manager* get_hardware_manager() const = 0;
   virtual backend_executor* get_executor(device_id dev) const = 0;
   virtual backend_allocator *get_allocator(device_id dev) const = 0;
+
+  virtual std::string get_name() const = 0;
 
   virtual ~backend() {}
 

--- a/include/hipSYCL/runtime/device_id.hpp
+++ b/include/hipSYCL/runtime/device_id.hpp
@@ -113,6 +113,31 @@ private:
   int _device_id;
 };
 
+class platform_id {
+public:
+  platform_id(backend_id b, int platform)
+      : _backend{b}, _platform_id{platform} {}
+
+  platform_id() = default;
+
+  platform_id(device_id dev) : _backend{dev.get_backend()}, _platform_id{0} {}
+
+  backend_id get_backend() const { return _backend; }
+
+  int get_platform() const { return _platform_id; }
+
+  friend bool operator==(const platform_id &a, const platform_id &b) {
+    return a._backend == b._backend && a._platform_id == b._platform_id;
+  }
+
+  friend bool operator!=(const platform_id &a, const platform_id &b) {
+    return !(a == b);
+  }
+private:
+  backend_id _backend;
+  int _platform_id;
+};
+
 }
 }
 

--- a/include/hipSYCL/runtime/hip/hip_backend.hpp
+++ b/include/hipSYCL/runtime/hip/hip_backend.hpp
@@ -53,6 +53,8 @@ public:
   virtual backend_executor* get_executor(device_id dev) const override;
   virtual backend_allocator *get_allocator(device_id dev) const override;
 
+  virtual std::string get_name() const override;
+
   virtual ~hip_backend(){}
 
 private:

--- a/include/hipSYCL/runtime/omp/omp_backend.hpp
+++ b/include/hipSYCL/runtime/omp/omp_backend.hpp
@@ -50,6 +50,8 @@ public:
   virtual backend_executor* get_executor(device_id dev) const override;
   virtual backend_allocator *get_allocator(device_id dev) const override;
 
+  virtual std::string get_name() const override;
+  
   virtual ~omp_backend(){}
 
 private:

--- a/include/hipSYCL/sycl/device.hpp
+++ b/include/hipSYCL/sycl/device.hpp
@@ -56,6 +56,7 @@ inline rt::device_id get_host_device() {
                        0};
 }
 
+
 }
 
 class device_selector;
@@ -63,6 +64,8 @@ class platform;
 
 class device {
   friend class queue;
+  friend class context;
+  friend class platform;
 public:
   device(rt::device_id id)
       : _device_id{id} {}
@@ -92,9 +95,16 @@ public:
                rt::hardware_platform::rocm;
   }
 
-  bool is_accelerator() const 
-  {
-    return !is_cpu();
+  bool is_accelerator() const { return !is_cpu(); }
+
+  bool hipSYCL_has_compiled_kernels() const {
+#ifdef HIPSYCL_PLATFORM_CPU
+    return is_cpu();
+#elif defined(HIPSYCL_PLATFORM_CUDA)
+    return _device_id.get_backend() == rt::backend_id::cuda;
+#elif defined(HIPSYCL_PLATFORM_ROCM)
+    return _device_id.get_backend() == rt::backend_id::hip;
+#endif
   }
 
   // Implemented in platform.hpp
@@ -578,7 +588,6 @@ HIPSYCL_SPECIALIZE_GET_INFO(device, reference_count)
   // no reference counting is required.
   return 1;
 }
-
 
 } // namespace sycl
 } // namespace hipsycl

--- a/include/hipSYCL/sycl/device_selector.hpp
+++ b/include/hipSYCL/sycl/device_selector.hpp
@@ -80,7 +80,17 @@ class gpu_selector : public device_selector
 public:
   virtual ~gpu_selector() {}
   virtual int operator()(const device &dev) const {
-    return dev.is_gpu();
+    if (dev.is_gpu()) {
+      // Would be good to prefer a device for which
+      // we have actually compiled kernel code, because,
+      // I don't know, a user might try to run kernels..
+      if (dev.hipSYCL_has_compiled_kernels())
+        return 2;
+      else
+        return 1;
+      
+    }
+    return 0;
   }
 };
 

--- a/src/runtime/cuda/cuda_backend.cpp
+++ b/src/runtime/cuda/cuda_backend.cpp
@@ -81,6 +81,10 @@ backend_allocator *cuda_backend::get_allocator(device_id dev) const {
   }
   return &(_allocators[dev.get_id()]);
 }
+
+std::string cuda_backend::get_name() const {
+  return "CUDA";
+}
   
 }
 }

--- a/src/runtime/hip/hip_backend.cpp
+++ b/src/runtime/hip/hip_backend.cpp
@@ -90,6 +90,10 @@ backend_allocator *hip_backend::get_allocator(device_id dev) const {
   }
   return &(_allocators[dev.get_id()]);
 }
+
+std::string hip_backend::get_name() const {
+  return "HIP";
+}
   
 }
 }

--- a/src/runtime/omp/omp_backend.cpp
+++ b/src/runtime/omp/omp_backend.cpp
@@ -87,5 +87,9 @@ backend_allocator* omp_backend::get_allocator(device_id dev) const {
   return &_allocator;
 }
 
+std::string omp_backend::get_name() const {
+  return "OpenMP";
+}
+
 }
 }


### PR DESCRIPTION
Until now, `context` and `platform` were implemented mostly as trivial dummy classes. This was possible because we had separate runtime libraries for CPU, ROCm, CUDA, such that there could never be more than one backend active at the same time in any hipSYCL program. Even without those classes it was therefore always clear which backend is targeted.

With the new runtime, this is no longer the case - all backends will show up and can be active at the same time. While actual context management is done by the runtime behind the scenes, we now need to at least store a device list inside a `context` for USM. This is because the USM memory management functions need to know which backend to ask e.g. for a memory allocation. The specification expects that this information is extracted from a `context`, so we actually need to store device information in contexts.

This PR is therefore a key prerequisite for the implementation of USM.

Also cleans up the involved classes to make better use of the new runtime.

Note that the new `context` implementation in principle exceeds the specification in the sense that it allows `context` to potentially span multiple backends/platforms. This is for future work :)