### PR TITLE
[SYCL 2020][USM] Add USM memory management functions and usm_allocator

### DIFF
--- a/include/hipSYCL/runtime/allocator.hpp
+++ b/include/hipSYCL/runtime/allocator.hpp
@@ -34,10 +34,24 @@
 namespace hipsycl {
 namespace rt {
 
+struct pointer_info {
+  // Device on which memory is allocator. For shared allocations
+  // this might not have reliable semantics
+  rt::device_id dev;
+
+  bool is_optimized_host;
+  bool is_usm;
+  // Whether the allocation came from a host backend where
+  // semantics can be slightly different (e.g. everything is
+  // automatically "usm")
+  bool is_from_host_backend;
+};
+
 class backend_allocator
 {
 public:
-  virtual void* allocate(size_t min_alignment, size_t size_bytes) = 0;
+  virtual void *allocate(size_t min_alignment, size_t size_bytes) = 0;
+  // Optimized host memory - may be page-locked, device mapped if supported
   virtual void* allocate_optimized_host(size_t min_alignment, size_t bytes) = 0;
   virtual void free(void *mem) = 0;
   
@@ -45,6 +59,10 @@ public:
   /// Allocate memory accessible both from the host and the backend
   virtual void *allocate_usm(size_t bytes) = 0;
   virtual bool is_usm_accessible_from(backend_descriptor b) const = 0;
+
+  // Query the given pointer for its properties. If pointer is unknown,
+  // returns non-success result.
+  virtual result query_pointer(const void* ptr, pointer_info& out) const = 0;
   
   virtual ~backend_allocator(){}
 };

--- a/include/hipSYCL/runtime/cuda/cuda_allocator.hpp
+++ b/include/hipSYCL/runtime/cuda/cuda_allocator.hpp
@@ -36,7 +36,7 @@ namespace rt {
 class cuda_allocator : public backend_allocator 
 {
 public:
-  cuda_allocator(int cuda_device);
+  cuda_allocator(backend_descriptor desc, int cuda_device);
 
   virtual void* allocate(size_t min_alignment, size_t size_bytes) override;
 
@@ -50,7 +50,10 @@ public:
   virtual void *allocate_usm(size_t bytes) override;
   virtual bool is_usm_accessible_from(backend_descriptor b) const override;
 
+  virtual result query_pointer(const void* ptr, pointer_info& out) const override;
+
 private:
+  backend_descriptor _backend_descriptor;
   int _dev;
 };
 

--- a/include/hipSYCL/runtime/device_list.hpp
+++ b/include/hipSYCL/runtime/device_list.hpp
@@ -31,6 +31,7 @@
 #include <algorithm>
 #include <vector>
 
+#include "application.hpp"
 #include "device_id.hpp"
 
 namespace hipsycl {
@@ -55,13 +56,13 @@ public:
   }
 
   template <class F> void for_each_device(F f) const {
-    for (const rt::device_id &dev : _devices) {
+    for (const device_id &dev : _devices) {
       f(dev);
     }
   }
 
   template <class F> void for_each_backend(F f) const {
-    for (const rt::backend_id &b : _backends) {
+    for (const backend_id &b : _backends) {
       f(b);
     }
   }
@@ -75,9 +76,40 @@ public:
                          const unique_device_list &b) {
     return !(a == b);
   }
+
+  std::size_t get_num_backends(hardware_platform plat) const {
+    std::size_t count = 0;
+
+    for_each_backend([&](backend_id b) {
+      if (application::get_backend(b).get_hardware_platform() == plat)
+        ++count;
+    });
+    
+    return count;
+  }
+
+  std::size_t get_num_backends() const { return _backends.size(); }
+
+  using backend_iterator = std::vector<backend_id>::const_iterator;
+  using device_iterator = std::vector<device_id>::const_iterator;
+
+  backend_iterator backends_begin() const { return _backends.begin(); }
+  backend_iterator backends_end() const { return _backends.end(); }
+  device_iterator devices_begin() const { return _devices.begin(); }
+  device_iterator devices_end() const { return _devices.end(); }
+
+  template <class UnaryPredicate>
+  device_iterator find_first_device(UnaryPredicate p) const {
+    return std::find_if(devices_begin(), devices_end(), p);
+  }
+
+  template <class UnaryPredicate>
+  backend_iterator find_first_backend(UnaryPredicate p) const {
+    return std::find_if(backends_begin(), backends_end(), p);
+  }
 private:
-  std::vector<rt::device_id> _devices;
-  std::vector<rt::backend_id> _backends;
+  std::vector<device_id> _devices;
+  std::vector<backend_id> _backends;
 };
 
 }

--- a/include/hipSYCL/runtime/hip/hip_allocator.hpp
+++ b/include/hipSYCL/runtime/hip/hip_allocator.hpp
@@ -37,7 +37,7 @@ namespace rt {
 class hip_allocator : public backend_allocator 
 {
 public:
-  hip_allocator(int hip_device);
+  hip_allocator(backend_descriptor desc, int hip_device);
 
   virtual void* allocate(size_t min_alignment, size_t size_bytes) override;
 
@@ -51,7 +51,9 @@ public:
   virtual void *allocate_usm(size_t bytes) override;
   virtual bool is_usm_accessible_from(backend_descriptor b) const override;
 
+  virtual result query_pointer(const void* ptr, pointer_info& out) const override;
 private:
+  backend_descriptor _backend_descriptor;
   int _dev;
 };
 

--- a/include/hipSYCL/runtime/omp/omp_allocator.hpp
+++ b/include/hipSYCL/runtime/omp/omp_allocator.hpp
@@ -36,6 +36,8 @@ namespace rt {
 class omp_allocator : public backend_allocator 
 {
 public:
+  omp_allocator(const device_id &my_device);
+  
   virtual void* allocate(size_t min_alignment, size_t size_bytes) override;
 
   virtual void *allocate_optimized_host(size_t min_alignment,
@@ -45,6 +47,12 @@ public:
 
   virtual void *allocate_usm(size_t bytes) override;
   virtual bool is_usm_accessible_from(backend_descriptor b) const override;
+
+  virtual result query_pointer(const void *ptr,
+                               pointer_info &out) const override;
+
+private:
+  device_id _my_device;
 };
 
 }

--- a/include/hipSYCL/sycl/buffer.hpp
+++ b/include/hipSYCL/sycl/buffer.hpp
@@ -611,13 +611,13 @@ private:
             rt::application::get_backend(host_device.get_backend())
                 .get_allocator(host_device)
                 ->allocate_optimized_host(
-                    128, _impl->data->get_num_elements().size() * sizeof(T));
+                    0, _impl->data->get_num_elements().size() * sizeof(T));
       } else {
         host_ptr =
             rt::application::get_backend(host_device.get_backend())
                 .get_allocator(host_device)
                 ->allocate(
-                    128, _impl->data->get_num_elements().size() * sizeof(T));
+                    0, _impl->data->get_num_elements().size() * sizeof(T));
       }
 
       if(!host_ptr)

--- a/include/hipSYCL/sycl/context.hpp
+++ b/include/hipSYCL/sycl/context.hpp
@@ -45,11 +45,19 @@
 namespace hipsycl {
 namespace sycl {
 
+class context;
+
+namespace detail {
+const rt::unique_device_list& extract_context_devices(const context&);
+}
 
 class context
 {
 public:
   friend class queue;
+
+  friend const rt::unique_device_list &
+  detail::extract_context_devices(const context &);
 
   explicit context(async_handler handler = [](exception_list e) {
     glue::default_async_handler(e);
@@ -164,6 +172,14 @@ inline context exception::get_context() const {
   // ToDo In hipSYCL, most operations are not associated
   // with a context at all, so just return empty one?
   return context{};
+}
+
+namespace detail {
+
+inline const rt::unique_device_list &extract_context_devices(const context &ctx) {
+  return ctx._impl->devices;
+}
+
 }
 
 } // namespace sycl

--- a/include/hipSYCL/sycl/device.hpp
+++ b/include/hipSYCL/sycl/device.hpp
@@ -48,6 +48,8 @@
 namespace hipsycl {
 namespace sycl {
 
+class device;
+
 namespace detail {
 
 inline rt::device_id get_host_device() {
@@ -56,6 +58,7 @@ inline rt::device_id get_host_device() {
                        0};
 }
 
+rt::device_id extract_rt_device(const device&);
 
 }
 
@@ -66,6 +69,7 @@ class device {
   friend class queue;
   friend class context;
   friend class platform;
+  friend rt::device_id detail::extract_rt_device(const device&);
 public:
   device(rt::device_id id)
       : _device_id{id} {}
@@ -587,6 +591,14 @@ HIPSYCL_SPECIALIZE_GET_INFO(device, reference_count)
   // hipSYCL device classes do not need any resources, and hence
   // no reference counting is required.
   return 1;
+}
+
+namespace detail {
+
+inline rt::device_id extract_rt_device(const device &d) {
+  return d._device_id;
+}
+
 }
 
 } // namespace sycl

--- a/include/hipSYCL/sycl/sycl.hpp
+++ b/include/hipSYCL/sycl/sycl.hpp
@@ -63,6 +63,7 @@
 #include "stream.hpp"
 #include "sub_group.hpp"
 #include "memory.hpp"
+#include "usm.hpp"
 
 #endif
 

--- a/include/hipSYCL/sycl/usm.hpp
+++ b/include/hipSYCL/sycl/usm.hpp
@@ -1,0 +1,462 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2020 Aksel Alpay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef HIPSYCL_USM_HPP
+#define HIPSYCL_USM_HPP
+
+#include <cstdint>
+#include <cassert>
+#include <exception>
+
+#include "context.hpp"
+#include "device.hpp"
+#include "queue.hpp"
+#include "exception.hpp"
+
+#include "hipSYCL/common/debug.hpp"
+#include "hipSYCL/glue/error.hpp"
+#include "hipSYCL/runtime/application.hpp"
+#include "hipSYCL/runtime/backend.hpp"
+#include "hipSYCL/runtime/allocator.hpp"
+
+namespace hipsycl {
+namespace sycl {
+
+namespace detail {
+
+
+inline rt::backend_id select_usm_backend(const context &ctx) {
+  const rt::unique_device_list &devs = detail::extract_context_devices(ctx);
+
+  if (devs.get_num_backends() == 0)
+    throw memory_allocation_error{
+        "USM: No backends to carry out USM memory management are present in "
+        "the context!"};
+
+
+  std::size_t num_host_backends =
+      devs.get_num_backends(rt::hardware_platform::cpu);
+
+  assert(devs.get_num_backends() >= num_host_backends);
+  std::size_t num_device_backends = devs.get_num_backends() - num_host_backends;
+
+  rt::backend_id selected_backend;
+
+  // Logic is simple: Prefer device backends if available over host backends.
+  if (num_device_backends > 0) {
+    if (num_device_backends > 1) {
+      HIPSYCL_DEBUG_WARNING
+          << "USM backend selection: Context contains multiple device "
+             "backends. "
+             "Using the first device backend as GUESS for USM memory "
+             "management. This might go TERRIBLY WRONG if you are not using "
+             "this backend for your kernels! "
+             "You are encouraged to better specify which backends you want to "
+             "target."
+          << std::endl;
+    }
+    auto backend_it = devs.find_first_backend([](rt::backend_id b) {
+      return rt::application::get_backend(b).get_hardware_platform() !=
+             rt::hardware_platform::cpu;
+    });
+    assert(backend_it != devs.backends_end());
+    selected_backend = *backend_it;
+
+  } else if (num_host_backends > 0) {
+    if (num_host_backends > 1) {
+      HIPSYCL_DEBUG_WARNING
+          << "USM backend selection: Context did not contain any device "
+             "backends, but multiple host backends. Using first host backend "
+             "(which should be fine as long as you run only on the host), but "
+             "you are encouraged to better specify which backend you wish to "
+             "carry out USM memory management"
+          << std::endl;
+    }
+    auto backend_it = devs.find_first_backend([](rt::backend_id b) {
+      return rt::application::get_backend(b).get_hardware_platform() ==
+             rt::hardware_platform::cpu;
+    });
+    assert(backend_it != devs.backends_end());
+    selected_backend = *backend_it;
+  }
+  
+  return selected_backend;
+}
+
+inline rt::backend_allocator *select_usm_allocator(const context &ctx) {
+  rt::backend_id selected_backend = select_usm_backend(ctx);
+
+  rt::backend &backend_object = rt::application::get_backend(selected_backend);
+
+  if (backend_object.get_hardware_manager()->get_num_devices() == 0)
+    throw memory_allocation_error{"USM: Context has no devices on which "
+                                  "requested operation could be carried out"};
+
+  return backend_object.get_allocator(
+      rt::device_id{backend_object.get_backend_descriptor(), 0});
+}
+
+inline rt::backend_allocator *select_usm_allocator(const context &ctx,
+                                                   const device &dev) {
+  rt::backend_id selected_backend = select_usm_backend(ctx);
+
+  rt::backend& backend_object = rt::application::get_backend(selected_backend);
+  return backend_object.get_allocator(detail::extract_rt_device(dev));
+}
+
+}
+
+namespace usm {
+enum class alloc { host, device, shared, unknown };
+}
+
+// Explicit USM
+
+inline void *malloc_device(size_t num_bytes, const device &dev,
+                           const context &ctx) {
+  return detail::select_usm_allocator(ctx, dev)->allocate(0, num_bytes);
+}
+
+template <typename T>
+T* malloc_device(std::size_t count, const device &dev,
+                       const context &ctx) {
+  return static_cast<T*>(malloc_device(count * sizeof(T), dev, ctx));
+}
+
+inline void *malloc_device(size_t num_bytes, const queue &q) {
+  return malloc_device(num_bytes, q.get_device(), q.get_context());
+}
+
+template <typename T>
+T* malloc_device(std::size_t count, const queue &q) {
+  return malloc_device<T>(count, q.get_device(), q.get_context());
+}
+
+inline void *aligned_alloc_device(std::size_t alignment, std::size_t num_bytes,
+                                  const device &dev, const context &ctx) {
+  return detail::select_usm_allocator(ctx, dev)->allocate(alignment, num_bytes);
+}
+
+template <typename T>
+T *aligned_alloc_device(std::size_t alignment, std::size_t count,
+                        const device &dev, const context &ctx) {
+  return static_cast<T *>(
+      aligned_alloc_device(alignment, count * sizeof(T), dev, ctx));
+}
+
+inline void *aligned_alloc_device(std::size_t alignment, std::size_t size,
+                                  const queue &q) {
+  return aligned_alloc_device(alignment, size, q.get_device(), q.get_context());
+}
+
+template <typename T>
+T *aligned_alloc_device(std::size_t alignment, std::size_t count,
+                        const queue &q) {
+  return aligned_alloc_device<T>(alignment, count, q.get_device(), q.get_context());
+}
+
+// Restricted USM
+
+inline void *malloc_host(std::size_t num_bytes, const context &ctx) {
+  return detail::select_usm_allocator(ctx)->allocate_optimized_host(0, num_bytes);
+}
+
+template <typename T> T *malloc_host(std::size_t count, const context &ctx) {
+  return static_cast<T*>(malloc_host(count * sizeof(T), ctx));
+}
+
+inline void *malloc_host(std::size_t num_bytes, const queue &q) {
+  return malloc_host(num_bytes, q.get_context());
+}
+
+template <typename T> T *malloc_host(std::size_t count, const queue &q) {
+  return malloc_host<T>(count, q.get_context());
+}
+
+inline void *malloc_shared(std::size_t num_bytes, const device &dev,
+                           const context &ctx) {
+  return detail::select_usm_allocator(ctx, dev)->allocate_usm(num_bytes);
+}
+
+template <typename T>
+T *malloc_shared(std::size_t count, const device &dev, const context &ctx) {
+  return static_cast<T*>(malloc_shared(count * sizeof(T), dev, ctx));
+}
+
+inline void *malloc_shared(std::size_t num_bytes, const queue &q) {
+  return malloc_shared(num_bytes, q.get_device(), q.get_context());
+}
+
+template <typename T> T *malloc_shared(std::size_t count, const queue &q) {
+  return malloc_shared<T>(count, q.get_device(), q.get_context());
+}
+
+inline void *aligned_alloc_host(std::size_t alignment, std::size_t num_bytes,
+                                const context &ctx) {
+  return detail::select_usm_allocator(ctx)->allocate_optimized_host(alignment,
+                                                                    num_bytes);
+}
+
+template <typename T>
+T *aligned_alloc_host(std::size_t alignment, size_t count, const context &ctx) {
+  return static_cast<T*>(aligned_alloc_host(alignment, count * sizeof(T), ctx));
+}
+
+inline void *aligned_alloc_host(size_t alignment, size_t num_bytes,
+                                const queue &q) {
+  return aligned_alloc_host(alignment, num_bytes, q.get_context());
+}
+
+template <typename T>
+void *aligned_alloc_host(std::size_t alignment, std::size_t count,
+                         const queue &q) {
+  return static_cast<T *>(
+      aligned_alloc_host(alignment, count * sizeof(T), q.get_context()));
+}
+
+inline void *aligned_alloc_shared(std::size_t alignment, std::size_t num_bytes,
+                                  const device &dev, const context &ctx) {
+  return detail::select_usm_allocator(ctx, dev)->allocate_usm(num_bytes);
+}
+
+template <typename T>
+T *aligned_alloc_shared(std::size_t alignment, std::size_t count,
+                        const device &dev, const context &ctx) {
+  return static_cast<T*>(aligned_alloc_shared(alignment, count * sizeof(T), dev, ctx));
+}
+
+inline void *aligned_alloc_shared(std::size_t alignment, std::size_t num_bytes,
+                                  const queue &q) {
+  return aligned_alloc_shared(alignment, num_bytes, q.get_device(), q.get_context());
+}
+
+template <typename T>
+T *aligned_alloc_shared(std::size_t alignment, std::size_t count,
+                        const queue &q) {
+  return static_cast<T *>(aligned_alloc_shared(
+      alignment, count * sizeof(T), q.get_device(), q.get_context()));
+}
+
+
+// General
+
+inline void *malloc(std::size_t num_bytes, const device &dev,
+                    const context &ctx, usm::alloc kind) {
+
+  if (kind == usm::alloc::device) {
+    return malloc_device(num_bytes, dev, ctx);
+  } else if (kind == usm::alloc::host) {
+    return malloc_host(num_bytes, ctx);
+  } else if (kind == usm::alloc::shared) {
+    return malloc_shared(num_bytes, dev, ctx);
+  }
+  return nullptr;
+}
+
+template <typename T>
+T *malloc(std::size_t count, const device &dev, const context &ctx,
+          usm::alloc kind) {
+  return static_cast<T*>(malloc(count * sizeof(T), dev, ctx, kind));
+}
+
+inline void *malloc(std::size_t num_bytes, const queue &q, usm::alloc kind) {
+  return malloc(num_bytes, q.get_device(), q.get_context(), kind);
+}
+
+template <typename T>
+T *malloc(std::size_t count, const queue &q, usm::alloc kind) {
+  return static_cast<T *>(
+      malloc(count * sizeof(T), q.get_device(), q.get_context(), kind));
+}
+
+inline void *aligned_alloc(std::size_t alignment, std::size_t num_bytes,
+                           const device &dev, const context &ctx,
+                           usm::alloc kind) {
+  if (kind == usm::alloc::device) {
+    return aligned_alloc_device(alignment, num_bytes, dev, ctx);
+  } else if (kind == usm::alloc::host) {
+    return aligned_alloc_host(alignment, num_bytes, ctx);
+  } else if (kind == usm::alloc::shared) {
+    return aligned_alloc_shared(alignment, num_bytes, dev, ctx);
+  }
+  return nullptr;
+}
+
+template <typename T>
+T *aligned_alloc(std::size_t alignment, std::size_t count, const device &dev,
+                 const context &ctx, usm::alloc kind) {
+  return static_cast<T *>(
+      aligned_alloc(alignment, count * sizeof(T), dev, ctx, kind));
+}
+
+inline void *aligned_alloc(std::size_t alignment, std::size_t num_bytes,
+                           const sycl::queue &q, usm::alloc kind) {
+  return aligned_alloc(alignment, num_bytes, q.get_device(), q.get_context(),
+                       kind);
+}
+
+template <typename T>
+T *aligned_alloc(std::size_t alignment, std::size_t count, const sycl::queue &q,
+                 usm::alloc kind) {
+  return static_cast<T *>(aligned_alloc(alignment, count * sizeof(T),
+                                        q.get_device(), q.get_context(), kind));
+}
+
+inline void free(void *ptr, const sycl::context &ctx) {
+  return detail::select_usm_allocator(ctx)->free(ptr);
+}
+
+inline void free(void *ptr, const sycl::queue &q) {
+  free(ptr, q.get_context());
+}
+
+// Not in the SYCL 2020 provisional spec, but probably simple oversight
+template <class T> void free(T *ptr, sycl::context &context) {
+  free(static_cast<void*>(ptr), context);
+}
+
+template<class T>
+void free(T *ptr, sycl::queue &q) {
+  free(static_cast<void*>(ptr), q.get_context());
+}
+
+usm::alloc get_pointer_type(const void *ptr, const context &ctx) {
+  rt::pointer_info info;
+  rt::result res = detail::select_usm_allocator(ctx)->query_pointer(ptr, info);
+
+  if (!res.is_success())
+    return usm::alloc::unknown;
+
+  if (info.is_from_host_backend || info.is_optimized_host)
+    return usm::alloc::host;
+  else if (info.is_usm)
+    return usm::alloc::shared;
+  else
+    return usm::alloc::device;
+}
+
+sycl::device get_pointer_device(const void *ptr, const context &ctx) {
+  rt::pointer_info info;
+  rt::result res = detail::select_usm_allocator(ctx)->query_pointer(ptr, info);
+
+  if (!res.is_success())
+    std::rethrow_exception(glue::throw_result(res));
+
+  if (info.is_from_host_backend){
+    // TODO Spec says to return *the* host device, but it might be better
+    // to return a device from the actual host backend used
+    // (we might want to have multiple host devices/backends in the future)
+    return detail::get_host_device();
+  }
+  else if (info.is_optimized_host) {
+    // Return first (non-host?) device from context
+    const rt::unique_device_list &devs = detail::extract_context_devices(ctx);
+
+    auto device_iterator =
+        devs.find_first_device([](rt::device_id d) { return !d.is_host(); });
+
+    assert(device_iterator != devs.devices_end());
+    return device{*device_iterator};
+  }
+  else
+    return device{info.dev};
+}
+
+
+template <typename T, usm::alloc AllocKind, std::size_t Alignment = 0>
+class usm_allocator {
+public:
+  using value_type = T;
+  using propagate_on_container_copy_assignment = std::true_type;
+  using propagate_on_container_move_assignment = std::true_type;
+  using propagate_on_container_swap = std::true_type;
+
+public:
+  template <typename U> struct rebind {
+    typedef usm_allocator<U, AllocKind, Alignment> other;
+  };
+
+  static_assert(
+      AllocKind != usm::alloc::device,
+      "usm_allocator does not support AllocKind == usm::alloc::device");
+
+  usm_allocator() noexcept = delete;
+  usm_allocator(const context &ctx, const device &dev) noexcept
+      : _ctx{ctx}, _dev{dev} {}
+
+
+  usm_allocator(const queue &q) noexcept
+      : _ctx{q.get_context()}, _dev{q.get_device()} {}
+  
+  usm_allocator(const usm_allocator &) noexcept = default;
+  usm_allocator(usm_allocator &&) noexcept = default;
+
+  usm_allocator &operator=(const usm_allocator &) = delete;
+  usm_allocator &operator=(usm_allocator &&) = default;
+
+  template <class U>
+  usm_allocator(const usm_allocator<U, AllocKind, Alignment> &other) noexcept
+      : _ctx{other._ctx}, _dev{other._dev} {}
+
+  T *allocate(std::size_t num_elements) {
+
+    T *ptr = aligned_alloc<T>(Alignment, num_elements, _dev, _ctx, AllocKind);
+
+    if (!ptr)
+      throw memory_allocation_error("usm_allocator: Allocation failed");
+
+    return ptr;
+  }
+
+  void deallocate(T *ptr, std::size_t size) {
+    if (ptr)
+      free(ptr, _ctx);
+  }
+
+  template <class U, usm::alloc AllocKindU, size_t AlignmentU>
+  friend bool operator==(const usm_allocator<T, AllocKind, Alignment> &a,
+                         const usm_allocator<U, AllocKindU, AlignmentU> &b) {
+    return a._dev == b._dev && a._ctx == b._ctx && AllocKindU == AllocKind &&
+           AlignmentU == Alignment;
+  }
+
+  template <class U, usm::alloc AllocKindU, size_t AlignmentU>
+  friend bool operator!=(const usm_allocator<T, AllocKind, Alignment> &a,
+                         const usm_allocator<U, AllocKindU, AlignmentU> &b) {
+    return !(a == b);
+  }
+
+private:
+  context _ctx;
+  device _dev;
+
+};
+
+}
+} // namespace hipsycl
+
+#endif

--- a/src/runtime/cuda/cuda_backend.cpp
+++ b/src/runtime/cuda/cuda_backend.cpp
@@ -37,8 +37,10 @@ cuda_backend::cuda_backend()
                   return std::make_unique<cuda_queue>(dev);
                 }} {
 
+  backend_descriptor backend_desc{get_hardware_platform(), get_api_platform()};
+
   for (int i = 0; i < _hw_manager.get_num_devices(); ++i) {
-    _allocators.push_back(cuda_allocator{i});
+    _allocators.push_back(cuda_allocator{backend_desc, i});
   }
 }
 

--- a/src/runtime/dag_direct_scheduler.cpp
+++ b/src/runtime/dag_direct_scheduler.cpp
@@ -95,7 +95,7 @@ result ensure_allocation_exists(buffer_memory_requirement *bmem_req,
     
     void *ptr = application::get_backend(target_dev.get_backend())
                     .get_allocator(target_dev)
-                    ->allocate(128, num_bytes);
+                    ->allocate(0, num_bytes);
 
     if(!ptr)
       return register_error(

--- a/src/runtime/dag_expander.cpp
+++ b/src/runtime/dag_expander.cpp
@@ -475,7 +475,7 @@ void dag_expander::expand(
               // TODO: Find out optimal minimum alignment
               return application::get_backend(target_device.get_backend())
                   .get_allocator(target_device)
-                  ->allocate(128, num_elements.size() * element_size);
+                  ->allocate(0, num_elements.size() * element_size);
             };
 
             HIPSYCL_DEBUG_INFO

--- a/src/runtime/hip/hip_backend.cpp
+++ b/src/runtime/hip/hip_backend.cpp
@@ -38,8 +38,10 @@ hip_backend::hip_backend()
                   return std::make_unique<hip_queue>(dev);
                 }} {
 
+  backend_descriptor backend_desc{get_hardware_platform(), get_api_platform()};
+
   for (int i = 0; i < _hw_manager.get_num_devices(); ++i) {
-    _allocators.push_back(hip_allocator{i});
+    _allocators.push_back(hip_allocator{backend_desc, i});
   }
 }
 

--- a/src/runtime/omp/omp_allocator.cpp
+++ b/src/runtime/omp/omp_allocator.cpp
@@ -32,11 +32,15 @@
 namespace hipsycl {
 namespace rt {
 
+omp_allocator::omp_allocator(const device_id &my_device)
+    : _my_device{my_device} {}
 
-void* omp_allocator::allocate(size_t min_alignment, size_t size_bytes) {
+void *omp_allocator::allocate(size_t min_alignment, size_t size_bytes) {
+  if (min_alignment <= 1)
+    return malloc(size_bytes);
+  
   if(size_bytes % min_alignment != 0)
-    // TODO: Return error?
-    return allocate(1, size_bytes);
+    return nullptr;
 
   // ToDo: Mac OS CI has a problem with std::aligned_alloc
   // but it's unclear if it's a Mac, or libc++, or toolchain issue
@@ -57,7 +61,7 @@ void omp_allocator::free(void *mem) {
 }
 
 void* omp_allocator::allocate_usm(size_t bytes) {
-  return this->allocate(128, bytes);
+  return this->allocate(0, bytes);
 }
 
 bool omp_allocator::is_usm_accessible_from(backend_descriptor b) const {
@@ -65,6 +69,17 @@ bool omp_allocator::is_usm_accessible_from(backend_descriptor b) const {
     return true;
   }
   return false;
+}
+
+result omp_allocator::query_pointer(const void *ptr, pointer_info &out) const {
+  
+  // For a host device, USM is the same as host memory?
+  out.is_optimized_host = true;
+  out.is_usm = true;
+  out.is_from_host_backend = true;
+  out.dev = _my_device;
+
+  return make_success();
 }
 
 }

--- a/src/runtime/omp/omp_backend.cpp
+++ b/src/runtime/omp/omp_backend.cpp
@@ -45,7 +45,9 @@ std::unique_ptr<inorder_queue> make_omp_queue(device_id dev) {
 }
 
 omp_backend::omp_backend()
-    : _allocator{}, _hw{},
+    : _allocator{device_id{
+          backend_descriptor{get_hardware_platform(), get_api_platform()}, 0}},
+      _hw{},
       _executor(*this, [](device_id dev) -> std::unique_ptr<inorder_queue> {
         return make_omp_queue(dev);
       }) {}


### PR DESCRIPTION
This adds USM memory management functions, pointer query functions, and `usm_allocator`. USM tests will follow later as we will need more functionality (in particular `memcpy`) for proper testing.

Known caveats:
* As far as I am aware, CUDA and HIP do not allow specifying alignments for allocations. The SYCL aligned memory allocation functions therefore currently ignore the alignment argument on CUDA and HIP. On CPU it should work as expected.
* HIP/ROCm only has partial support for shared allocations (unified memory in CUDA terminology). My understanding is that it is currently implemented as mapped host memory in ROCm, which means that performance will probably be very bad as every memory access goes across PCIe. I suspect that this is due to hardware limitations, and I expect that this will change with future AMD hardware. After all, AMD has promised a  "coherent" architecture for Frontier and El Capitan. hipSYCL correctly calls `hipMallocManaged()` for shared allocations, so when this is improved hipSYCL will be ready.
* Because of the previous point, I believe that there currently is no way in ROCm to distinguish between "shared" and (pinned) "host" allocations. So, I expect that pointer queries for SYCL shared allocations would identify as SYCL host allocations. We use the HIP pointer property `hipMemoryTypeUnified` to check for shared allocations; the HIP documentation says that it is currently not yet used but I suspect that this would be the right one when this is properly implemented in ROCm.
