### PR TITLE
syclcc work around Clang bug with -std=gnu++xx for CUDA

### DIFF
--- a/bin/syclcc-clang
+++ b/bin/syclcc-clang
@@ -478,6 +478,9 @@ class clang_plugin_compiler:
       self._compiler_args += ["-x", "cuda",
                               "--cuda-gpu-arch=" + config.target_arch,
                               "--cuda-path=" + config.cuda_path]
+      # clang erroneously sets feature detection flags for __float128 even though it is not supported for CUDA,
+      # see https://bugs.llvm.org/show_bug.cgi?id=47559.
+      self._compiler_args += ["-U__FLOAT128__", "-U__SIZEOF_FLOAT128__"]
       
     elif target == hipsycl_platform.HIP:
       self._target = "hip"

--- a/bin/syclcc-clang
+++ b/bin/syclcc-clang
@@ -342,10 +342,6 @@ class syclcc_config:
         std_version = std_args[0].strip("c++").strip("gnu++")
         if std_version in self._insufficient_cpp_standards:
             raise RuntimeError("Insufficient c++ standard '{}'".format(std_args[0]))
-        if std_args[0].startswith('gnu++') and self.target_platform == hipsycl_platform.CUDA:
-            print('syclcc warning: -std=' + std_args[0]
-                  + ' breaks the Clang CUDA target, expect compile errors in standard library. '
-                    'See https://bugs.llvm.org/show_bug.cgi?id=47559 for details.')
         return []
 
   @property

--- a/bin/syclcc-clang
+++ b/bin/syclcc-clang
@@ -463,39 +463,17 @@ class clang_plugin_compiler:
     if target == hipsycl_platform.CUDA:
       self._linker_args = config.cuda_link_line
 
-      self._compiler_args = []
-      # automatically link hipSYCL
-      self._linker_args += [
-        "-rpath", hipsycl_library_path,
-        "-L"+hipsycl_library_path,
-        "-lhipSYCL-rt"
-      ]
-      self._compiler_args += [
+      self._compiler_args = [
+        "-x", "cuda",
+        "--cuda-gpu-arch=" + config.target_arch,
+        "--cuda-path=" + config.cuda_path,
         # Use the bundled HIP installation
         "-I" + os.path.join(config.hipsycl_installation_path, "include/hipSYCL/contrib")
       ]
-      
-      self._compiler_args += ["-x", "cuda",
-                              "--cuda-gpu-arch=" + config.target_arch,
-                              "--cuda-path=" + config.cuda_path]
-      # clang erroneously sets feature detection flags for __float128 even though it is not supported for CUDA,
-      # see https://bugs.llvm.org/show_bug.cgi?id=47559.
-      self._compiler_args += ["-U__FLOAT128__", "-U__SIZEOF_FLOAT128__"]
-      
+
     elif target == hipsycl_platform.HIP:
-      self._target = "hip"
-      
       self._linker_args = config.rocm_link_line
 
-      # automatically link hipSYCL
-
-      self._linker_args += [
-        "-rpath", hipsycl_library_path,
-        "-L"+hipsycl_library_path,
-        "-lhipSYCL-rt"
-      ]
-      
-      
       self._compiler_args = [
         "-x", "hip",
         "--cuda-gpu-arch=" + config.target_arch,
@@ -509,6 +487,17 @@ class clang_plugin_compiler:
         "-isystem", self._get_rocm_clang_include_path(config)
       ]
 
+    # clang erroneously sets feature detection flags for __float128 even though it is not supported for CUDA / HIP,
+    # see https://bugs.llvm.org/show_bug.cgi?id=47559.
+    self._compiler_args += ["-U__FLOAT128__", "-U__SIZEOF_FLOAT128__"]
+
+    # automatically link hipSYCL
+    self._linker_args += [
+      "-rpath", hipsycl_library_path,
+      "-L"+hipsycl_library_path,
+      "-lhipSYCL-rt"
+    ]
+
     self._common_compiler_args = config.common_compiler_args
 
     self._common_compiler_args += [
@@ -521,7 +510,6 @@ class clang_plugin_compiler:
     return config.clang_include_path
 
   def run(self):
-
     command = [self._clang] + self._common_compiler_args
 
     if self._contains_compilation_stage:

--- a/bin/syclcc-clang
+++ b/bin/syclcc-clang
@@ -342,6 +342,10 @@ class syclcc_config:
         std_version = std_args[0].strip("c++").strip("gnu++")
         if std_version in self._insufficient_cpp_standards:
             raise RuntimeError("Insufficient c++ standard '{}'".format(std_args[0]))
+        if std_args[0].startswith('gnu++') and self.target_platform == hipsycl_platform.CUDA:
+            print('syclcc warning: -std=' + std_args[0]
+                  + ' breaks the Clang CUDA target, expect compile errors in standard library. '
+                    'See https://bugs.llvm.org/show_bug.cgi?id=47559 for details.')
         return []
 
   @property


### PR DESCRIPTION
Calling syclcc on the CUDA backend with `-std=gnu++17` (which happens implicitly when setting the `CMAKE_CXX_STANDARD` to `17` after #309) will cause weird compiler errors relating to `__float128` not being defined in libstdc++:

```
In file included from <built-in>:1:
In file included from /usr/lib/clang/10.0.1/include/__clang_cuda_runtime_wrapper.h:36:
In file included from /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../include/c++/10.2.0/cmath:47:
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../include/c++/10.2.0/bits/std_abs.h:103:7: error: __float128 is not supported on this target
  abs(__float128 __x)
      ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../include/c++/10.2.0/bits/std_abs.h:102:3: error: __float128 is not supported on this target
  __float128
  ^
```

This is actually a [Clang bug](https://bugs.llvm.org/show_bug.cgi?id=47559) ~~the only workaroud I know so far is switching to `-std=c++17`. This PR adds a warning output to syclcc in case it is passed a `-std=gnu++` flag when operating on the CUDA platform as a stop-gap until the Clang issue is resolved. Please discuss whether a warning message is the right approach here.~~

This PR undefines the offending feature flags `__FLOAT128__` and `__SIZEOF_FLOAT128__` when invoking clang from syclcc, allowing other GNU extensions to remain functional.