### PR TITLE
Make HIPSYCL_SYCLCC_EXTRA_ARGS none-cache variable

### DIFF
--- a/cmake/hipsycl-config.cmake.in
+++ b/cmake/hipsycl-config.cmake.in
@@ -81,8 +81,7 @@ unset(HIPSYCL_PLATFORMS_STRING)
 unset(HIPSYCL_NUM_AVAILABLE_BACKENDS)
 unset(HIPSYCL_DEFAULT_PLATFORM)
 
-set(HIPSYCL_SYCLCC_EXTRA_ARGS "--hipsycl-platform=${HIPSYCL_PLATFORM}" CACHE STRING
-        "Extra compiler flags specific to syclcc that are incompatible with GCC/Clang")
+set(HIPSYCL_SYCLCC_EXTRA_ARGS "--hipsycl-platform=${HIPSYCL_PLATFORM}")
 
 set(HIPSYCL_CLANG "" CACHE STRING "Clang compiler executable used for compilation.")
 if(HIPSYCL_CLANG)


### PR DESCRIPTION
On my system, this has fixed the issue #316 . I could reproduce it with a sort of up to date arch Linux distro. After some "printf" debugging it was clear that the `HIPSYCL_SYCLCC_EXTRA_ARGS` won't be updated if there is already a value in the cache. Forcing the set has resolved the issue for me. 